### PR TITLE
Merge adapter wave 2: provider, LangSmith trace, Iterative Context MCP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/apple/pkl-go v0.13.2
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/cloudwego/eino v0.8.11
+	github.com/cloudwego/eino-ext/callbacks/langsmith v0.0.0-20260509111509-dbda66119839
 	github.com/cloudwego/eino-ext/components/model/openai v0.1.13
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/hmdsefi/gograph v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.8.11 h1:lf/j1VXQTzPV9/pXijgjAIELTxvZi6zbPobmv3h/gco=
 github.com/cloudwego/eino v0.8.11/go.mod h1:+2N4nsMPxA6kGBHpH+75JuTfEcGprAMTdsZESrShKpU=
+github.com/cloudwego/eino-ext/callbacks/langsmith v0.0.0-20260509111509-dbda66119839 h1:pgc8m6g8SeU5pAc8MfYQXsxKcNvwlkr41bxTWHzIG5g=
+github.com/cloudwego/eino-ext/callbacks/langsmith v0.0.0-20260509111509-dbda66119839/go.mod h1:zitSOw9AR+oAL68is1FET0XzJ+7swY4Yvoes2BRwlyE=
 github.com/cloudwego/eino-ext/components/model/openai v0.1.13 h1:5XHRTiTD5bt9KQrMHcfvuWNklEC3tpm3XHejdozt9vM=
 github.com/cloudwego/eino-ext/components/model/openai v0.1.13/go.mod h1:mgIoqYYOc0eECCqvLbEYpOJrQNTNxkwXzSJzFU+v5sQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.17 h1:EeVcR1TslRA2IdNW1h/2LaGbPlffwGhQm99jM3zWZiI=
@@ -151,6 +153,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/adapters/backend/iterativecontext/doc.go
+++ b/internal/adapters/backend/iterativecontext/doc.go
@@ -1,0 +1,12 @@
+// Package iterativecontext connects SearchBench evaluator runs to an Iterative Context MCP server.
+//
+// The adapter owns MCP session lifecycle, optional repo root registration, harness-owned
+// score installation ([Runtime.InstallScore], [Runtime.VerifyScore]) before evaluator tools
+// are listed, and MCP tools/call dispatch for evaluator-facing localization tools.
+//
+// Evaluator-visible tool lists intentionally exclude admin/install/verify tools even if the
+// server advertises them in tools/list.
+//
+// Production use starts a subprocess transport via [OpenCommand]. Tests should use [NewRuntime]
+// with an in-memory MCP session from [github.com/modelcontextprotocol/go-sdk/mcp.NewInMemoryTransports].
+package iterativecontext

--- a/internal/adapters/backend/iterativecontext/errors.go
+++ b/internal/adapters/backend/iterativecontext/errors.go
@@ -1,0 +1,89 @@
+package iterativecontext
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Kind classifies Iterative Context adapter failures for errors.Is-style checks.
+type Kind int
+
+const (
+	// KindSession covers MCP transport/session setup before a usable client session exists
+	// (connect, handshake).
+	KindSession Kind = iota
+	// KindInstall covers harness score installation via MCP install_score.
+	KindInstall
+	// KindVerify covers harness score verification via MCP verify_score.
+	KindVerify
+	// KindToolSetup covers evaluator tool surface preparation (tools/list and schema mapping).
+	KindToolSetup
+	// KindToolCall covers evaluator MCP tools/call failures and tool results marked as errors.
+	KindToolCall
+)
+
+// Error is a typed adapter failure with an operation label.
+type Error struct {
+	Kind Kind
+	Op   string
+	Err  error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	kind := "session"
+	switch e.Kind {
+	case KindInstall:
+		kind = "install"
+	case KindVerify:
+		kind = "verify"
+	case KindToolSetup:
+		kind = "tool_setup"
+	case KindToolCall:
+		kind = "tool"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("iterativecontext %s: %s", kind, e.Op)
+	}
+	return fmt.Sprintf("iterativecontext %s: %s: %v", kind, e.Op, e.Err)
+}
+
+// Unwrap implements error unwrapper semantics.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// IsSession reports whether err is (or wraps) an [Error] with [KindSession].
+func IsSession(err error) bool {
+	var ie *Error
+	return errors.As(err, &ie) && ie != nil && ie.Kind == KindSession
+}
+
+// IsInstall reports whether err is (or wraps) an [Error] with [KindInstall].
+func IsInstall(err error) bool {
+	var ie *Error
+	return errors.As(err, &ie) && ie != nil && ie.Kind == KindInstall
+}
+
+// IsVerify reports whether err is (or wraps) an [Error] with [KindVerify].
+func IsVerify(err error) bool {
+	var ie *Error
+	return errors.As(err, &ie) && ie != nil && ie.Kind == KindVerify
+}
+
+// IsToolSetup reports whether err is (or wraps) an [Error] with [KindToolSetup].
+func IsToolSetup(err error) bool {
+	var ie *Error
+	return errors.As(err, &ie) && ie != nil && ie.Kind == KindToolSetup
+}
+
+// IsToolCall reports whether err is (or wraps) an [Error] with [KindToolCall].
+func IsToolCall(err error) bool {
+	var ie *Error
+	return errors.As(err, &ie) && ie != nil && ie.Kind == KindToolCall
+}

--- a/internal/adapters/backend/iterativecontext/factory.go
+++ b/internal/adapters/backend/iterativecontext/factory.go
@@ -1,0 +1,67 @@
+package iterativecontext
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+
+// EvaluatorToolFactory returns an [run]-compatible tool factory backed by MCP tools exposed
+// through rt. Only evaluator-safe tools are listed (admin/install/verify tools are omitted).
+func EvaluatorToolFactory(rt *Runtime) func(run.Spec) ([]tool.BaseTool, error) {
+	return func(_ run.Spec) ([]tool.BaseTool, error) {
+		if rt == nil {
+			return nil, &Error{Kind: KindToolSetup, Op: "tool factory", Err: fmt.Errorf("nil runtime")}
+		}
+		ctx := context.Background()
+		tools, err := rt.ListEvaluatorTools(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var out []tool.BaseTool
+		for _, mt := range tools {
+			if mt == nil || strings.TrimSpace(mt.Name) == "" {
+				continue
+			}
+			info, err := ToolInfoFromMCP(mt)
+			if err != nil {
+				return nil, &Error{Kind: KindToolSetup, Op: fmt.Sprintf("tool %q", mt.Name), Err: err}
+			}
+			out = append(out, mcpInvokableTool{
+				rt:   rt,
+				name: mt.Name,
+				info: info,
+			})
+		}
+		if len(out) == 0 {
+			return nil, &Error{Kind: KindToolSetup, Op: "tool factory", Err: fmt.Errorf("server returned no evaluator tools")}
+		}
+		return out, nil
+	}
+}
+
+type mcpInvokableTool struct {
+	rt   *Runtime
+	name string
+	info *schema.ToolInfo
+}
+
+func (t mcpInvokableTool) Info(_ context.Context) (*schema.ToolInfo, error) {
+	return t.info, nil
+}
+
+func (t mcpInvokableTool) InvokableRun(ctx context.Context, input string, _ ...tool.Option) (string, error) {
+	raw := json.RawMessage(strings.TrimSpace(input))
+	if len(raw) == 0 {
+		raw = json.RawMessage(`{}`)
+	}
+	return t.rt.CallTool(ctx, t.name, raw)
+}
+
+var _ tool.InvokableTool = mcpInvokableTool{}

--- a/internal/adapters/backend/iterativecontext/iterativecontext_test.go
+++ b/internal/adapters/backend/iterativecontext/iterativecontext_test.go
@@ -1,0 +1,244 @@
+package iterativecontext_test
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+
+func objectSchema() map[string]any {
+	return map[string]any{"type": "object"}
+}
+
+func TestEvaluatorToolListHidesAdminTools(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	impl := &mcp.Implementation{Name: "ic-fake-server", Version: "v0"}
+	server := mcp.NewServer(impl, nil)
+
+	server.AddTool(&mcp.Tool{Name: "resolve", Description: "Resolve symbol", InputSchema: objectSchema()},
+		func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"ok": true}}, nil
+		})
+	server.AddTool(&mcp.Tool{Name: "install_score", Description: "admin", InputSchema: objectSchema()},
+		func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"ok": true}}, nil
+		})
+	server.AddTool(&mcp.Tool{Name: "verify_score", Description: "admin", InputSchema: objectSchema()},
+		func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"ok": true}}, nil
+		})
+
+	st, ct := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(impl, nil)
+	clientSession, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	rt := iterativecontext.NewRuntime(clientSession)
+	factory := iterativecontext.EvaluatorToolFactory(rt)
+	tools, err := factory(run.Spec{})
+	if err != nil {
+		t.Fatalf("tool factory: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools len: got %d want 1 (admin tools filtered)", len(tools))
+	}
+	info, err := tools[0].Info(ctx)
+	if err != nil {
+		t.Fatalf("tool info: %v", err)
+	}
+	if info.Name != "resolve" {
+		t.Fatalf("unexpected tool name %q", info.Name)
+	}
+}
+
+func TestPrepareScoreInstallBeforeVerify(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	impl := &mcp.Implementation{Name: "ic-fake-server", Version: "v0"}
+	server := mcp.NewServer(impl, nil)
+
+	var mu sync.Mutex
+	installedPolicy := ""
+
+	osch := objectSchema()
+	server.AddTool(&mcp.Tool{Name: "install_score", Description: "install", InputSchema: osch},
+		func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var args map[string]any
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return &mcp.CallToolResult{StructuredContent: map[string]any{"error": err.Error()}}, nil
+			}
+			pid, _ := args["policy_id"].(string)
+			mu.Lock()
+			installedPolicy = pid
+			mu.Unlock()
+			return &mcp.CallToolResult{StructuredContent: map[string]any{
+				"ok": true, "policy_id": pid,
+			}}, nil
+		})
+	server.AddTool(&mcp.Tool{Name: "verify_score", Description: "verify", InputSchema: osch},
+		func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			var args map[string]any
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return &mcp.CallToolResult{StructuredContent: map[string]any{"error": err.Error()}}, nil
+			}
+			want, _ := args["policy_id"].(string)
+			mu.Lock()
+			got := installedPolicy
+			mu.Unlock()
+			if got == "" {
+				return &mcp.CallToolResult{StructuredContent: map[string]any{
+					"error": "no score installed for this runtime session",
+				}}, nil
+			}
+			if got != want {
+				return &mcp.CallToolResult{StructuredContent: map[string]any{
+					"error": "policy mismatch",
+				}}, nil
+			}
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"ok": true, "policy_id": got}}, nil
+		})
+
+	st, ct := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(impl, nil)
+	clientSession, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	rt := iterativecontext.NewRuntime(clientSession)
+
+	if err := rt.VerifyScore(ctx, "pol-1"); err == nil {
+		t.Fatal("verify before install: expected error")
+	} else if !iterativecontext.IsVerify(err) {
+		t.Fatalf("expected verify error kind, got %v", err)
+	}
+
+	if err := iterativecontext.PrepareScore(ctx, rt, iterativecontext.ScoreInstallParams{
+		PolicyPath: "/tmp/fake_policy.py",
+		PolicyID:   "pol-1",
+	}); err != nil {
+		t.Fatalf("PrepareScore: %v", err)
+	}
+
+	factory := iterativecontext.EvaluatorToolFactory(rt)
+	_, ferr := factory(run.Spec{})
+	if ferr == nil {
+		t.Fatal("expected error: no evaluator tools registered on fake server")
+	}
+	if !iterativecontext.IsToolSetup(ferr) {
+		t.Fatalf("expected tool_setup error, got %v", ferr)
+	}
+}
+
+func TestInstallScoreSurfacesJSONErrorKind(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	impl := &mcp.Implementation{Name: "ic-fake-server", Version: "v0"}
+	server := mcp.NewServer(impl, nil)
+
+	server.AddTool(&mcp.Tool{Name: "install_score", Description: "install", InputSchema: objectSchema()},
+		func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"error": "bad module"}}, nil
+		})
+
+	st, ct := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(impl, nil)
+	clientSession, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	rt := iterativecontext.NewRuntime(clientSession)
+	err = rt.InstallScore(ctx, iterativecontext.ScoreInstallParams{PolicyPath: "/x", PolicyID: "p"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !iterativecontext.IsInstall(err) {
+		t.Fatalf("expected install error kind, got %v", err)
+	}
+}
+
+func TestCallToolEvaluatorSurfacesToolKind(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	impl := &mcp.Implementation{Name: "ic-fake-server", Version: "v0"}
+	server := mcp.NewServer(impl, nil)
+
+	server.AddTool(&mcp.Tool{Name: "resolve", Description: "Resolve", InputSchema: objectSchema()},
+		func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: "boom"}},
+			}, nil
+		})
+
+	st, ct := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(impl, nil)
+	clientSession, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	rt := iterativecontext.NewRuntime(clientSession)
+	_, err = rt.CallTool(ctx, "resolve", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !iterativecontext.IsToolCall(err) {
+		t.Fatalf("expected tool-call error, got %v", err)
+	}
+}
+
+func TestOpenCommandFailsSession(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := iterativecontext.OpenCommand(ctx, iterativecontext.CommandConfig{
+		Command: exec.Command("false"),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !iterativecontext.IsSession(err) {
+		t.Fatalf("expected session error, got %v", err)
+	}
+}

--- a/internal/adapters/backend/iterativecontext/normalize.go
+++ b/internal/adapters/backend/iterativecontext/normalize.go
@@ -1,0 +1,61 @@
+package iterativecontext
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NormalizeCallToolResult turns an MCP tools/call result into a single JSON string for Eino.
+//
+// When the result is not an MCP error payload but [mcp.CallToolResult.IsError] is set,
+// this returns an [Error] with [KindToolCall].
+func NormalizeCallToolResult(res *mcp.CallToolResult) (string, error) {
+	if res == nil {
+		return "", fmt.Errorf("nil CallToolResult")
+	}
+	if res.IsError {
+		return "", &Error{
+			Kind: KindToolCall,
+			Op:   "tool returned error",
+			Err:  fmt.Errorf("%s", textFromContent(res.Content)),
+		}
+	}
+	if res.StructuredContent != nil {
+		raw, err := json.Marshal(res.StructuredContent)
+		if err != nil {
+			return "", &Error{Kind: KindToolCall, Op: "marshal structuredContent", Err: err}
+		}
+		return string(raw), nil
+	}
+	if out := textFromContent(res.Content); out != "" {
+		return out, nil
+	}
+	if len(res.Content) > 0 {
+		raw, err := json.Marshal(res.Content)
+		if err != nil {
+			return "", &Error{Kind: KindToolCall, Op: "marshal content", Err: err}
+		}
+		return string(raw), nil
+	}
+	return "{}", nil
+}
+
+func textFromContent(parts []mcp.Content) string {
+	var b strings.Builder
+	for _, part := range parts {
+		if part == nil {
+			continue
+		}
+		switch t := part.(type) {
+		case *mcp.TextContent:
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(t.Text)
+		}
+	}
+	return b.String()
+}

--- a/internal/adapters/backend/iterativecontext/runtime.go
+++ b/internal/adapters/backend/iterativecontext/runtime.go
@@ -1,0 +1,197 @@
+package iterativecontext
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Tool names reserved for harness-side score setup; never exposed to the evaluator tool list.
+var excludedEvaluatorToolNames = map[string]struct{}{
+	"install_score": {},
+	"verify_score":  {},
+}
+
+// ScoreInstallParams selects a policy module on disk and the deterministic identity used by the harness.
+type ScoreInstallParams struct {
+	PolicyPath string
+	PolicyID   string
+	// Symbol names the callable inside the policy module; empty means the server default (score_fn).
+	Symbol string
+}
+
+// Runtime holds a live MCP client session for Iterative Context tool servers.
+type Runtime struct {
+	session *mcp.ClientSession
+}
+
+// NewRuntime wraps an initialized MCP client session. The caller must have already
+// completed the MCP initialize handshake (for example via [mcp.Client.Connect]).
+func NewRuntime(session *mcp.ClientSession) *Runtime {
+	if session == nil {
+		return nil
+	}
+	return &Runtime{session: session}
+}
+
+// Session returns the underlying MCP session for advanced call sites.
+func (r *Runtime) Session() *mcp.ClientSession {
+	if r == nil {
+		return nil
+	}
+	return r.session
+}
+
+// Close ends the MCP session.
+func (r *Runtime) Close() error {
+	if r == nil || r.session == nil {
+		return nil
+	}
+	return r.session.Close()
+}
+
+// listMCPTools returns the full paginated tools/list payload from the server.
+func (r *Runtime) listMCPTools(ctx context.Context) ([]*mcp.Tool, error) {
+	if r == nil || r.session == nil {
+		return nil, &Error{Kind: KindToolSetup, Op: "list tools", Err: fmt.Errorf("nil runtime")}
+	}
+	var (
+		all    []*mcp.Tool
+		cursor string
+	)
+	for {
+		res, err := r.session.ListTools(ctx, &mcp.ListToolsParams{Cursor: cursor})
+		if err != nil {
+			return nil, &Error{Kind: KindToolSetup, Op: "mcp tools/list", Err: err}
+		}
+		all = append(all, res.Tools...)
+		if res.NextCursor == "" {
+			break
+		}
+		cursor = res.NextCursor
+	}
+	return all, nil
+}
+
+// ListEvaluatorTools returns MCP tools intended for the evaluator after stripping harness-admin tools.
+func (r *Runtime) ListEvaluatorTools(ctx context.Context) ([]*mcp.Tool, error) {
+	all, err := r.listMCPTools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []*mcp.Tool
+	for _, t := range all {
+		if t == nil || strings.TrimSpace(t.Name) == "" {
+			continue
+		}
+		if _, hide := excludedEvaluatorToolNames[t.Name]; hide {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+// PrepareScore installs then verifies the active score identity for this MCP session.
+func PrepareScore(ctx context.Context, rt *Runtime, p ScoreInstallParams) error {
+	if err := rt.InstallScore(ctx, p); err != nil {
+		return err
+	}
+	return rt.VerifyScore(ctx, strings.TrimSpace(p.PolicyID))
+}
+
+// InstallScore invokes MCP install_score for this session.
+func (r *Runtime) InstallScore(ctx context.Context, p ScoreInstallParams) error {
+	if r == nil || r.session == nil {
+		return &Error{Kind: KindInstall, Op: "install_score", Err: fmt.Errorf("nil runtime")}
+	}
+	path := strings.TrimSpace(p.PolicyPath)
+	id := strings.TrimSpace(p.PolicyID)
+	if path == "" || id == "" {
+		return &Error{Kind: KindInstall, Op: "install_score", Err: fmt.Errorf("policy_path and policy_id are required")}
+	}
+	args := map[string]any{
+		"policy_path": path,
+		"policy_id":   id,
+	}
+	if sym := strings.TrimSpace(p.Symbol); sym != "" {
+		args["symbol"] = sym
+	}
+	_, err := r.callAdminTool(ctx, KindInstall, "install_score", "install_score", args)
+	return err
+}
+
+// VerifyScore invokes MCP verify_score for this session.
+func (r *Runtime) VerifyScore(ctx context.Context, policyID string) error {
+	if r == nil || r.session == nil {
+		return &Error{Kind: KindVerify, Op: "verify_score", Err: fmt.Errorf("nil runtime")}
+	}
+	id := strings.TrimSpace(policyID)
+	if id == "" {
+		return &Error{Kind: KindVerify, Op: "verify_score", Err: fmt.Errorf("policy_id is required")}
+	}
+	args := map[string]any{"policy_id": id}
+	_, err := r.callAdminTool(ctx, KindVerify, "verify_score", "verify_score", args)
+	return err
+}
+
+func (r *Runtime) callAdminTool(ctx context.Context, kind Kind, op, name string, args map[string]any) (string, error) {
+	res, err := r.session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: args,
+	})
+	if err != nil {
+		return "", &Error{Kind: kind, Op: op, Err: err}
+	}
+	out, normErr := NormalizeCallToolResult(res)
+	if normErr != nil {
+		var je *Error
+		if errors.As(normErr, &je) && je != nil && je.Err != nil {
+			return "", &Error{Kind: kind, Op: op, Err: je.Err}
+		}
+		return "", &Error{Kind: kind, Op: op, Err: normErr}
+	}
+	if err := interpretScoreJSON(kind, op, out); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func interpretScoreJSON(kind Kind, op, payloadJSON string) error {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(payloadJSON), &m); err != nil {
+		return &Error{Kind: kind, Op: op, Err: fmt.Errorf("parse response JSON: %w", err)}
+	}
+	if msg, ok := m["error"].(string); ok && strings.TrimSpace(msg) != "" {
+		return &Error{Kind: kind, Op: op, Err: errors.New(strings.TrimSpace(msg))}
+	}
+	if ok, _ := m["ok"].(bool); !ok {
+		return &Error{Kind: kind, Op: op, Err: fmt.Errorf("response missing ok=true")}
+	}
+	return nil
+}
+
+// CallTool invokes MCP tools/call and normalizes the payload for the evaluator tool surface.
+func (r *Runtime) CallTool(ctx context.Context, name string, arguments json.RawMessage) (string, error) {
+	if r == nil || r.session == nil {
+		return "", &Error{Kind: KindToolCall, Op: "call tool", Err: fmt.Errorf("nil runtime")}
+	}
+	var args any
+	if len(arguments) > 0 {
+		if err := json.Unmarshal(arguments, &args); err != nil {
+			return "", &Error{Kind: KindToolCall, Op: "parse tool arguments", Err: err}
+		}
+	}
+	res, err := r.session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: args,
+	})
+	if err != nil {
+		return "", &Error{Kind: KindToolCall, Op: "mcp tools/call", Err: err}
+	}
+	return NormalizeCallToolResult(res)
+}

--- a/internal/adapters/backend/iterativecontext/session.go
+++ b/internal/adapters/backend/iterativecontext/session.go
@@ -1,0 +1,56 @@
+package iterativecontext
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// CommandConfig starts an MCP server subprocess over stdio and completes the MCP handshake.
+type CommandConfig struct {
+	// Command is the MCP server command (stdin/stdout JSON-RPC). Required.
+	Command *exec.Cmd
+	// RepoPath, when non-empty, is registered as an MCP root before connecting.
+	RepoPath string
+	// Client, when non-empty, is used as the MCP client; otherwise a default SearchBench client is created.
+	Client *mcp.Client
+	// ScoreInstall, when non-nil, runs [PrepareScore] immediately after a successful connect.
+	ScoreInstall *ScoreInstallParams
+}
+
+// OpenCommand connects to an Iterative Context MCP server launched as a subprocess.
+func OpenCommand(ctx context.Context, cfg CommandConfig) (*Runtime, error) {
+	if cfg.Command == nil {
+		return nil, &Error{Kind: KindSession, Op: "open command", Err: fmt.Errorf("nil command")}
+	}
+	client := cfg.Client
+	if client == nil {
+		client = mcp.NewClient(&mcp.Implementation{Name: "searchbench-go", Version: "dev"}, nil)
+	}
+
+	if cfg.RepoPath != "" {
+		uri, err := filePathToRootURI(cfg.RepoPath)
+		if err != nil {
+			return nil, &Error{Kind: KindSession, Op: "repo root uri", Err: err}
+		}
+		client.AddRoots(&mcp.Root{URI: uri})
+	}
+
+	transport := &mcp.CommandTransport{Command: cfg.Command}
+	sess, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		return nil, &Error{Kind: KindSession, Op: "mcp connect", Err: err}
+	}
+	rt := NewRuntime(sess)
+
+	if cfg.ScoreInstall != nil {
+		if err := PrepareScore(ctx, rt, *cfg.ScoreInstall); err != nil {
+			_ = rt.Close()
+			return nil, err
+		}
+	}
+
+	return rt, nil
+}

--- a/internal/adapters/backend/iterativecontext/toolinfo.go
+++ b/internal/adapters/backend/iterativecontext/toolinfo.go
@@ -1,0 +1,47 @@
+package iterativecontext
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudwego/eino/schema"
+	"github.com/eino-contrib/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ToolInfoFromMCP converts an MCP tool definition into Eino [schema.ToolInfo].
+func ToolInfoFromMCP(t *mcp.Tool) (*schema.ToolInfo, error) {
+	if t == nil {
+		return nil, fmt.Errorf("nil tool")
+	}
+	params, err := paramsFromInputSchema(t.InputSchema)
+	if err != nil {
+		return nil, fmt.Errorf("tool %q input schema: %w", t.Name, err)
+	}
+	desc := t.Description
+	return &schema.ToolInfo{
+		Name:        t.Name,
+		Desc:        desc,
+		ParamsOneOf: params,
+	}, nil
+}
+
+func paramsFromInputSchema(input any) (*schema.ParamsOneOf, error) {
+	if input == nil {
+		return schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{}), nil
+	}
+	raw, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	var js jsonschema.Schema
+	if err := json.Unmarshal(raw, &js); err != nil {
+		return schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+			"arguments": {
+				Desc: "Opaque JSON object arguments for the tool.",
+				Type: schema.String,
+			},
+		}), nil
+	}
+	return schema.NewParamsOneOfByJSONSchema(&js), nil
+}

--- a/internal/adapters/backend/iterativecontext/uri.go
+++ b/internal/adapters/backend/iterativecontext/uri.go
@@ -1,0 +1,26 @@
+package iterativecontext
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// filePathToRootURI turns a local filesystem path into a file-scheme URI suitable
+// for MCP roots (absolute path, forward slashes in the URI path segment).
+func filePathToRootURI(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", err
+	}
+	u := url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(abs),
+	}
+	return u.String(), nil
+}

--- a/internal/adapters/providers/evaluatormodel/doc.go
+++ b/internal/adapters/providers/evaluatormodel/doc.go
@@ -1,0 +1,14 @@
+// Package evaluatormodel resolves manifest evaluator model settings plus process
+// environment into an Eino ToolCallingChatModel factory. Provider SDK types stay
+// in this adapter; pure packages receive only usage records and execution results.
+//
+// Environment (OpenAI-compatible HTTP):
+//
+//	openai:     OPENAI_API_KEY, optional OPENAI_BASE_URL
+//	openrouter: OPENROUTER_API_KEY (or OPENAI_API_KEY), optional OPENROUTER_BASE_URL (default https://openrouter.ai/api/v1)
+//	cerebras:   CEREBRAS_API_KEY, optional CEREBRAS_BASE_URL (default https://api.cerebras.ai/v1)
+//
+// Manifest provider "fake" (or missing/empty provider) uses the local deterministic
+// fake model. If a cloud provider is selected but credentials are missing, the
+// factory falls back to the fake model so tests and CI stay offline by default.
+package evaluatormodel

--- a/internal/adapters/providers/evaluatormodel/factory.go
+++ b/internal/adapters/providers/evaluatormodel/factory.go
@@ -1,0 +1,112 @@
+package evaluatormodel
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	openai "github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/components/model"
+
+	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+
+// Config is manifest evaluator model configuration (provider-neutral).
+type Config struct {
+	Provider        string
+	Model           string
+	MaxOutputTokens int
+}
+
+// NewFactory returns a factory that honors [Config] and the environment.
+//
+// When credentials for a cloud provider are absent, the returned factory is the
+// same as [evaluatorfake.ModelFactory] so default validation runs need no secrets.
+func NewFactory(cfg Config) func(spec run.Spec) (model.ToolCallingChatModel, error) {
+	switch normalizeProvider(cfg.Provider) {
+	case "", "fake":
+		return evaluatorfake.ModelFactory
+	case "openai", "openrouter", "cerebras":
+		m, ok := newOpenAIChatModel(cfg)
+		if !ok {
+			return evaluatorfake.ModelFactory
+		}
+		return func(run.Spec) (model.ToolCallingChatModel, error) {
+			return m, nil
+		}
+	default:
+		return evaluatorfake.ModelFactory
+	}
+}
+
+func normalizeProvider(p string) string {
+	return strings.ToLower(strings.TrimSpace(p))
+}
+
+type openAICreds struct {
+	apiKey  string
+	baseURL string
+}
+
+func resolveOpenAICreds(provider string) openAICreds {
+	switch provider {
+	case "openai":
+		return openAICreds{
+			apiKey:  strings.TrimSpace(os.Getenv("OPENAI_API_KEY")),
+			baseURL: strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")),
+		}
+	case "openrouter":
+		key := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY"))
+		if key == "" {
+			key = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+		}
+		base := strings.TrimSpace(os.Getenv("OPENROUTER_BASE_URL"))
+		if base == "" {
+			base = "https://openrouter.ai/api/v1"
+		}
+		return openAICreds{apiKey: key, baseURL: base}
+	case "cerebras":
+		base := strings.TrimSpace(os.Getenv("CEREBRAS_BASE_URL"))
+		if base == "" {
+			base = "https://api.cerebras.ai/v1"
+		}
+		return openAICreds{
+			apiKey:  strings.TrimSpace(os.Getenv("CEREBRAS_API_KEY")),
+			baseURL: base,
+		}
+	default:
+		return openAICreds{}
+	}
+}
+
+func newOpenAIChatModel(cfg Config) (model.ToolCallingChatModel, bool) {
+	p := normalizeProvider(cfg.Provider)
+	creds := resolveOpenAICreds(p)
+	if creds.apiKey == "" {
+		return nil, false
+	}
+
+	modelName := strings.TrimSpace(cfg.Model)
+	if modelName == "" {
+		modelName = "gpt-4o-mini"
+	}
+
+	ocfg := &openai.ChatModelConfig{
+		APIKey: creds.apiKey,
+		Model:  modelName,
+	}
+	if creds.baseURL != "" {
+		ocfg.BaseURL = creds.baseURL
+	}
+	if cfg.MaxOutputTokens > 0 {
+		v := cfg.MaxOutputTokens
+		ocfg.MaxCompletionTokens = &v
+	}
+
+	m, err := openai.NewChatModel(context.Background(), ocfg)
+	if err != nil {
+		return nil, false
+	}
+	return m, true
+}

--- a/internal/adapters/providers/evaluatormodel/factory_test.go
+++ b/internal/adapters/providers/evaluatormodel/factory_test.go
@@ -1,0 +1,125 @@
+package evaluatormodel
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/testing/modeltest"
+)
+
+func TestNewFactoryFakeProviderUsesLocalFake(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	f := NewFactory(Config{Provider: "fake"})
+	m, err := f(sampleSpec())
+	if err != nil {
+		t.Fatalf("factory(spec) error = %v", err)
+	}
+	msg, err := m.Generate(context.Background(), []*schema.Message{
+		schema.UserMessage("hi"),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if msg == nil || len(msg.ToolCalls) == 0 {
+		t.Fatalf("expected fake model tool call turn, got %#v", msg)
+	}
+}
+
+func TestNewFactoryOpenAIWithoutCredentialsUsesLocalFake(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("CEREBRAS_API_KEY", "")
+
+	f := NewFactory(Config{Provider: "openai", Model: "gpt-4o-mini"})
+	m, err := f(sampleSpec())
+	if err != nil {
+		t.Fatalf("factory(spec) error = %v", err)
+	}
+	msg, err := m.Generate(context.Background(), []*schema.Message{
+		schema.UserMessage("hi"),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if msg == nil || len(msg.ToolCalls) == 0 {
+		t.Fatalf("expected fallback fake tool call turn, got %#v", msg)
+	}
+}
+
+func TestNewFactoryOpenAIWithFixtureServer(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_BASE_URL", "")
+
+	server := modeltest.NewFakeOpenAIServer(modeltest.FakeResponse{
+		Status: http.StatusOK,
+		Body:   string(modeltest.MustFixture("chat_completion_success.json")),
+	})
+	t.Cleanup(server.Close)
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", server.BaseURL())
+
+	f := NewFactory(Config{Provider: "openai", Model: "gpt-4o-mini"})
+	m, err := f(sampleSpec())
+	if err != nil {
+		t.Fatalf("factory(spec) error = %v", err)
+	}
+	msg, err := m.Generate(context.Background(), []*schema.Message{
+		schema.UserMessage("Say hello"),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if got, want := msg.Content, `{"files":["pkg/example.go"],"reasoning":"fixture"}`; got != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+	reqs := server.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("len(requests) = %d, want 1", len(reqs))
+	}
+}
+
+func TestNewFactoryOpenRouterUsesOpenRouterEnv(t *testing.T) {
+	server := modeltest.NewFakeOpenAIServer(modeltest.FakeResponse{
+		Status: http.StatusOK,
+		Body:   string(modeltest.MustFixture("chat_completion_success.json")),
+	})
+	t.Cleanup(server.Close)
+
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "router-key")
+	t.Setenv("OPENROUTER_BASE_URL", server.BaseURL())
+
+	f := NewFactory(Config{Provider: "openrouter", Model: "meta/llama"})
+	m, err := f(sampleSpec())
+	if err != nil {
+		t.Fatalf("factory(spec) error = %v", err)
+	}
+	_, err = m.Generate(context.Background(), []*schema.Message{
+		schema.UserMessage("x"),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if len(server.Requests()) != 1 {
+		t.Fatalf("expected one HTTP request to fixture server")
+	}
+}
+
+func sampleSpec() run.Spec {
+	return run.Spec{
+		ID: "incumbent-m1-sys",
+		Match: domain.MatchSpec{
+			ID: "m1",
+		},
+		System: domain.SystemSpec{
+			Model: domain.ModelSpec{Provider: "openai", Name: "gpt-4o-mini"},
+		},
+	}
+}

--- a/internal/adapters/trace/langsmith/context.go
+++ b/internal/adapters/trace/langsmith/context.go
@@ -1,0 +1,63 @@
+package langsmith
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+
+	extlangsmith "github.com/cloudwego/eino-ext/callbacks/langsmith"
+)
+
+// ContextLabels carries non-authoritative dimensions for LangSmith trace UX only.
+type ContextLabels struct {
+	SessionName string
+	MatchID     string
+	RunID       string
+	Role        string
+}
+
+// AugmentContext attaches LangSmith trace options when LANGSMITH_API_KEY is set.
+// It does not perform scoring or decisions and does not replace SearchBench usage
+// accounting.
+func AugmentContext(ctx context.Context, labels ContextLabels) context.Context {
+	if strings.TrimSpace(os.Getenv(EnvAPIKey)) == "" {
+		return ctx
+	}
+
+	session := strings.TrimSpace(labels.SessionName)
+	if session == "" {
+		session = strings.TrimSpace(os.Getenv(EnvSession))
+	}
+	if session == "" {
+		session = "searchbench"
+	}
+
+	opts := []extlangsmith.TraceOption{
+		extlangsmith.WithSessionName(session),
+		extlangsmith.AddTag("searchbench"),
+	}
+	if id := strings.TrimSpace(labels.MatchID); id != "" {
+		opts = append(opts, extlangsmith.AddTag("match_id:"+id))
+	}
+	if id := strings.TrimSpace(labels.RunID); id != "" {
+		opts = append(opts, extlangsmith.AddTag("run_id:"+id))
+	}
+	if role := strings.TrimSpace(labels.Role); role != "" {
+		opts = append(opts, extlangsmith.AddTag("role:"+role))
+	}
+
+	meta := &sync.Map{}
+	if v := strings.TrimSpace(labels.MatchID); v != "" {
+		meta.Store("searchbench.match_id", v)
+	}
+	if v := strings.TrimSpace(labels.RunID); v != "" {
+		meta.Store("searchbench.run_id", v)
+	}
+	if v := strings.TrimSpace(labels.Role); v != "" {
+		meta.Store("searchbench.role", v)
+	}
+	opts = append(opts, extlangsmith.SetMetadata(meta))
+
+	return extlangsmith.SetTrace(ctx, opts...)
+}

--- a/internal/adapters/trace/langsmith/factory.go
+++ b/internal/adapters/trace/langsmith/factory.go
@@ -1,0 +1,66 @@
+// Package langsmith is the SearchBench adapter boundary for optional LangSmith/Eino
+// trace callbacks. SearchBench bundle, scoring, evidence, and decisions remain
+// authoritative; this integration is observational only and must not define core
+// domain types.
+package langsmith
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	extlangsmith "github.com/cloudwego/eino-ext/callbacks/langsmith"
+	einocallbacks "github.com/cloudwego/eino/callbacks"
+)
+
+// Well-known environment variables for optional LangSmith export (same names as
+// LangChain/LangSmith tooling when applicable).
+const (
+	EnvAPIKey = "LANGSMITH_API_KEY"
+	EnvAPIURL = "LANGSMITH_API_URL"
+	// EnvSession overrides the default LangSmith session name for trace grouping.
+	EnvSession = "SEARCHBENCH_LANGSMITH_SESSION"
+)
+
+// Config configures construction of the upstream LangSmith Eino callback handler.
+type Config struct {
+	APIKey string
+	APIURL string
+	// RunIDGen is forwarded to the upstream handler; nil uses its default.
+	RunIDGen func(context.Context) string
+}
+
+// HandlerFactory matches the evaluator callback composer shape
+// (internal/agents/evaluator/eino/callbacks.Factory).
+type HandlerFactory func(context.Context) (einocallbacks.Handler, error)
+
+// NewHandlerFactory returns a cold factory that yields the LangChain LangSmith
+// Eino handler, or (nil, nil) when APIKey is empty so tracing stays off without
+// credentials.
+func NewHandlerFactory(cfg Config) (HandlerFactory, error) {
+	key := strings.TrimSpace(cfg.APIKey)
+	if key == "" {
+		return nil, nil
+	}
+	upstream := &extlangsmith.Config{
+		APIKey:   key,
+		APIURL:   strings.TrimSpace(cfg.APIURL),
+		RunIDGen: cfg.RunIDGen,
+	}
+	h, err := extlangsmith.NewLangsmithHandler(upstream)
+	if err != nil {
+		return nil, err
+	}
+	return func(context.Context) (einocallbacks.Handler, error) {
+		return h, nil
+	}, nil
+}
+
+// HandlerFactoryFromEnv builds a factory from LANGSMITH_API_KEY /
+// LANGSMITH_API_URL. When the API key is unset, returns (nil, nil).
+func HandlerFactoryFromEnv() (HandlerFactory, error) {
+	return NewHandlerFactory(Config{
+		APIKey: os.Getenv(EnvAPIKey),
+		APIURL: os.Getenv(EnvAPIURL),
+	})
+}

--- a/internal/adapters/trace/langsmith/factory_test.go
+++ b/internal/adapters/trace/langsmith/factory_test.go
@@ -1,0 +1,71 @@
+package langsmith
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewHandlerFactory_DisabledWithoutAPIKey(t *testing.T) {
+	t.Parallel()
+
+	f, err := NewHandlerFactory(Config{})
+	if err != nil {
+		t.Fatalf("NewHandlerFactory() error = %v", err)
+	}
+	if f != nil {
+		t.Fatal("expected nil factory without API key")
+	}
+}
+
+func TestHandlerFactoryFromEnv_DefaultOffline(t *testing.T) {
+	t.Setenv(EnvAPIKey, "")
+	f, err := HandlerFactoryFromEnv()
+	if err != nil {
+		t.Fatalf("HandlerFactoryFromEnv() error = %v", err)
+	}
+	if f != nil {
+		t.Fatal("expected nil factory with empty env")
+	}
+}
+
+func TestNewHandlerFactory_EnabledWithAPIKey(t *testing.T) {
+	t.Parallel()
+
+	f, err := NewHandlerFactory(Config{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewHandlerFactory() error = %v", err)
+	}
+	if f == nil {
+		t.Fatal("expected non-nil factory")
+	}
+	h, err := f(context.Background())
+	if err != nil {
+		t.Fatalf("factory() error = %v", err)
+	}
+	if h == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestAugmentContext_NoKeyNoOp(t *testing.T) {
+	t.Setenv(EnvAPIKey, "")
+	ctx := context.Background()
+	out := AugmentContext(ctx, ContextLabels{MatchID: "m1"})
+	if out != ctx {
+		t.Fatal("expected same context when tracing disabled")
+	}
+}
+
+func TestAugmentContext_WithKeyAddsTrace(t *testing.T) {
+	t.Setenv(EnvAPIKey, "k")
+	ctx := context.Background()
+	out := AugmentContext(ctx, ContextLabels{
+		SessionName: "sess",
+		MatchID:     "mid",
+		RunID:       "rid",
+		Role:        "incumbent",
+	})
+	if out == ctx {
+		t.Fatal("expected derived context when tracing enabled")
+	}
+}

--- a/internal/app/round/evaluator.go
+++ b/internal/app/round/evaluator.go
@@ -10,7 +10,9 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 
 	evaluatormodel "github.com/becker63/searchbench-go/internal/adapters/providers/evaluatormodel"
+	langsmithtrace "github.com/becker63/searchbench-go/internal/adapters/trace/langsmith"
 	evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
+	evaluatorcallbacks "github.com/becker63/searchbench-go/internal/agents/evaluator/eino/callbacks"
 	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
 	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
 	"github.com/becker63/searchbench-go/internal/pure/domain"
@@ -112,17 +114,33 @@ func (e *evaluatorExecutor) Execute(ctx context.Context, spec run.Spec) (run.Exe
 	}
 	tools = filtered
 
+	var callbackFactories []evaluatorcallbacks.Factory
+	langsmithFactory, lsErr := langsmithtrace.HandlerFactoryFromEnv()
+	if lsErr != nil {
+		return run.ExecutedRun{}, fmt.Errorf("langsmith trace callback: %w", lsErr)
+	}
+	if langsmithFactory != nil {
+		callbackFactories = append(callbackFactories, evaluatorcallbacks.Factory(langsmithFactory))
+	}
+
 	evaluator, err := evaluatoreino.New(evaluatoreino.Config{
-		Model:       model,
-		Tools:       tools,
-		WorkDir:     string(spec.Match.Repo.Path),
-		RetryPolicy: &e.retryPolicy,
+		Model:             model,
+		Tools:             tools,
+		WorkDir:           string(spec.Match.Repo.Path),
+		RetryPolicy:       &e.retryPolicy,
+		CallbackFactories: callbackFactories,
 	})
 	if err != nil {
 		return run.ExecutedRun{}, fmt.Errorf("construct evaluator executor: %w", err)
 	}
 
-	result := evaluator.Run(ctx, spec)
+	runCtx := langsmithtrace.AugmentContext(ctx, langsmithtrace.ContextLabels{
+		MatchID: spec.Match.ID.String(),
+		RunID:   spec.ID.String(),
+		Role:    string(roleForSpec(spec)),
+	})
+
+	result := evaluator.Run(runCtx, spec)
 	e.recordExecution(spec, result)
 	if result.Failure != nil {
 		return run.ExecutedRun{}, result.Failure

--- a/internal/app/round/evaluator.go
+++ b/internal/app/round/evaluator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cloudwego/eino/components/tool"
 
+	evaluatormodel "github.com/becker63/searchbench-go/internal/adapters/providers/evaluatormodel"
 	evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
 	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
 	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
@@ -22,8 +23,18 @@ func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (r
 	for _, name := range plan.Evaluator.ToolPolicy.EffectiveAllowed {
 		allowedTools[name] = struct{}{}
 	}
+
+	modelFactory := request.EvaluatorModelFactory
+	if modelFactory == nil {
+		modelFactory = evaluatormodel.NewFactory(evaluatormodel.Config{
+			Provider:        plan.Evaluator.Model.Provider,
+			Model:           plan.Evaluator.Model.Name,
+			MaxOutputTokens: plan.Evaluator.Model.MaxOutputTokens,
+		})
+	}
+
 	executor := &evaluatorExecutor{
-		modelFactory: request.EvaluatorModelFactory,
+		modelFactory: modelFactory,
 		toolFactory:  request.EvaluatorToolFactory,
 		allowedTools: allowedTools,
 		evaluatorAppendix: run.EvaluatorRunAppendix{
@@ -79,6 +90,7 @@ func (e *evaluatorExecutor) Execute(ctx context.Context, spec run.Spec) (run.Exe
 
 	modelFactory := e.modelFactory
 	if modelFactory == nil {
+		// Defensive: runComparison normally injects evaluatormodel.NewFactory.
 		modelFactory = evaluatorfake.ModelFactory
 	}
 	model, err := modelFactory(spec)

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -12295,7 +12295,9 @@ import (
 	"github.com/cloudwego/eino/components/tool"
 
 	evaluatormodel "github.com/becker63/searchbench-go/internal/adapters/providers/evaluatormodel"
+	langsmithtrace "github.com/becker63/searchbench-go/internal/adapters/trace/langsmith"
 	evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
+	evaluatorcallbacks "github.com/becker63/searchbench-go/internal/agents/evaluator/eino/callbacks"
 	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
 	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
 	"github.com/becker63/searchbench-go/internal/pure/domain"
@@ -12312,7 +12314,9 @@ import (
 "github.com/cloudwego/eino/components/tool"
 ⋮----
 evaluatormodel "github.com/becker63/searchbench-go/internal/adapters/providers/evaluatormodel"
+langsmithtrace "github.com/becker63/searchbench-go/internal/adapters/trace/langsmith"
 evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
+evaluatorcallbacks "github.com/becker63/searchbench-go/internal/agents/evaluator/eino/callbacks"
 evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
 "github.com/becker63/searchbench-go/internal/app/round/internal/compare"
 "github.com/becker63/searchbench-go/internal/pure/domain"
@@ -12331,6 +12335,8 @@ type evaluatorExecutor struct {
 func (e *evaluatorExecutor) Execute(ctx context.Context, spec run.Spec) (run.ExecutedRun, error)
 ⋮----
 // Defensive: runComparison normally injects evaluatormodel.NewFactory.
+⋮----
+var callbackFactories []evaluatorcallbacks.Factory
 ⋮----
 func (e *evaluatorExecutor) recordExecution(spec run.Spec, result evaluatoreino.Result)
 ⋮----
@@ -17667,6 +17673,7 @@ require (
 	github.com/apple/pkl-go v0.13.2
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/cloudwego/eino v0.8.11
+	github.com/cloudwego/eino-ext/callbacks/langsmith v0.0.0-20260509111509-dbda66119839
 	github.com/cloudwego/eino-ext/components/model/openai v0.1.13
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/hmdsefi/gograph v0.7.0

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -144,6 +144,11 @@ internal/
         doc.go
         runner_test.go
         runner.go
+    providers/
+      evaluatormodel/
+        doc.go
+        factory_test.go
+        factory.go
     report/
       text/
         doc.go
@@ -156,6 +161,11 @@ internal/
         doc.go
         run_test.go
         run.go
+    trace/
+      langsmith/
+        context.go
+        factory_test.go
+        factory.go
   agents/
     evaluator/
       eino/
@@ -8493,6 +8503,109 @@ var exitErr *exec.ExitError
 func normalizeResult(spec ports.CommandSpec, result ports.StepResult) ports.StepResult
 </file>
 
+<file path="internal/adapters/providers/evaluatormodel/doc.go">
+// Package evaluatormodel resolves manifest evaluator model settings plus process
+// environment into an Eino ToolCallingChatModel factory. Provider SDK types stay
+// in this adapter; pure packages receive only usage records and execution results.
+//
+// Environment (OpenAI-compatible HTTP):
+⋮----
+//	openai:     OPENAI_API_KEY, optional OPENAI_BASE_URL
+//	openrouter: OPENROUTER_API_KEY (or OPENAI_API_KEY), optional OPENROUTER_BASE_URL (default https://openrouter.ai/api/v1)
+//	cerebras:   CEREBRAS_API_KEY, optional CEREBRAS_BASE_URL (default https://api.cerebras.ai/v1)
+⋮----
+// Manifest provider "fake" (or missing/empty provider) uses the local deterministic
+// fake model. If a cloud provider is selected but credentials are missing, the
+// factory falls back to the fake model so tests and CI stay offline by default.
+package evaluatormodel
+</file>
+
+<file path="internal/adapters/providers/evaluatormodel/factory_test.go">
+package evaluatormodel
+⋮----
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/cloudwego/eino/schema"
+
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/testing/modeltest"
+)
+⋮----
+"context"
+"net/http"
+"testing"
+⋮----
+"github.com/cloudwego/eino/schema"
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/domain"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+"github.com/becker63/searchbench-go/internal/testing/modeltest"
+⋮----
+func TestNewFactoryFakeProviderUsesLocalFake(t *testing.T)
+⋮----
+func TestNewFactoryOpenAIWithoutCredentialsUsesLocalFake(t *testing.T)
+⋮----
+func TestNewFactoryOpenAIWithFixtureServer(t *testing.T)
+⋮----
+func TestNewFactoryOpenRouterUsesOpenRouterEnv(t *testing.T)
+⋮----
+func sampleSpec() run.Spec
+</file>
+
+<file path="internal/adapters/providers/evaluatormodel/factory.go">
+package evaluatormodel
+⋮----
+import (
+	"context"
+	"os"
+	"strings"
+
+	openai "github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/components/model"
+
+	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+⋮----
+"context"
+"os"
+"strings"
+⋮----
+openai "github.com/cloudwego/eino-ext/components/model/openai"
+"github.com/cloudwego/eino/components/model"
+⋮----
+evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+⋮----
+// Config is manifest evaluator model configuration (provider-neutral).
+type Config struct {
+	Provider        string
+	Model           string
+	MaxOutputTokens int
+}
+⋮----
+// NewFactory returns a factory that honors [Config] and the environment.
+//
+// When credentials for a cloud provider are absent, the returned factory is the
+// same as [evaluatorfake.ModelFactory] so default validation runs need no secrets.
+func NewFactory(cfg Config) func(spec run.Spec) (model.ToolCallingChatModel, error)
+⋮----
+func normalizeProvider(p string) string
+⋮----
+type openAICreds struct {
+	apiKey  string
+	baseURL string
+}
+⋮----
+func resolveOpenAICreds(provider string) openAICreds
+⋮----
+func newOpenAIChatModel(cfg Config) (model.ToolCallingChatModel, bool)
+</file>
+
 <file path="internal/adapters/report/text/doc.go">
 // Package text renders Searchbench artifacts for human terminal output.
 //
@@ -8796,6 +8909,119 @@ func renderEvidenceRef(name string, ref score.ObjectiveEvidenceRef) string
 func fileURI(path string) string
 ⋮----
 func firstNonEmpty(values ...string) string
+</file>
+
+<file path="internal/adapters/trace/langsmith/context.go">
+package langsmith
+⋮----
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+
+	extlangsmith "github.com/cloudwego/eino-ext/callbacks/langsmith"
+)
+⋮----
+"context"
+"os"
+"strings"
+"sync"
+⋮----
+extlangsmith "github.com/cloudwego/eino-ext/callbacks/langsmith"
+⋮----
+// ContextLabels carries non-authoritative dimensions for LangSmith trace UX only.
+type ContextLabels struct {
+	SessionName string
+	MatchID     string
+	RunID       string
+	Role        string
+}
+⋮----
+// AugmentContext attaches LangSmith trace options when LANGSMITH_API_KEY is set.
+// It does not perform scoring or decisions and does not replace SearchBench usage
+// accounting.
+func AugmentContext(ctx context.Context, labels ContextLabels) context.Context
+</file>
+
+<file path="internal/adapters/trace/langsmith/factory_test.go">
+package langsmith
+⋮----
+import (
+	"context"
+	"testing"
+)
+⋮----
+"context"
+"testing"
+⋮----
+func TestNewHandlerFactory_DisabledWithoutAPIKey(t *testing.T)
+⋮----
+func TestHandlerFactoryFromEnv_DefaultOffline(t *testing.T)
+⋮----
+func TestNewHandlerFactory_EnabledWithAPIKey(t *testing.T)
+⋮----
+func TestAugmentContext_NoKeyNoOp(t *testing.T)
+⋮----
+func TestAugmentContext_WithKeyAddsTrace(t *testing.T)
+</file>
+
+<file path="internal/adapters/trace/langsmith/factory.go">
+// Package langsmith is the SearchBench adapter boundary for optional LangSmith/Eino
+// trace callbacks. SearchBench bundle, scoring, evidence, and decisions remain
+// authoritative; this integration is observational only and must not define core
+// domain types.
+package langsmith
+⋮----
+import (
+	"context"
+	"os"
+	"strings"
+
+	extlangsmith "github.com/cloudwego/eino-ext/callbacks/langsmith"
+	einocallbacks "github.com/cloudwego/eino/callbacks"
+)
+⋮----
+"context"
+"os"
+"strings"
+⋮----
+extlangsmith "github.com/cloudwego/eino-ext/callbacks/langsmith"
+einocallbacks "github.com/cloudwego/eino/callbacks"
+⋮----
+// Well-known environment variables for optional LangSmith export (same names as
+// LangChain/LangSmith tooling when applicable).
+const (
+	EnvAPIKey = "LANGSMITH_API_KEY"
+	EnvAPIURL = "LANGSMITH_API_URL"
+	// EnvSession overrides the default LangSmith session name for trace grouping.
+	EnvSession = "SEARCHBENCH_LANGSMITH_SESSION"
+)
+⋮----
+// EnvSession overrides the default LangSmith session name for trace grouping.
+⋮----
+// Config configures construction of the upstream LangSmith Eino callback handler.
+type Config struct {
+	APIKey string
+	APIURL string
+	// RunIDGen is forwarded to the upstream handler; nil uses its default.
+	RunIDGen func(context.Context) string
+}
+⋮----
+// RunIDGen is forwarded to the upstream handler; nil uses its default.
+⋮----
+// HandlerFactory matches the evaluator callback composer shape
+// (internal/agents/evaluator/eino/callbacks.Factory).
+type HandlerFactory func(context.Context) (einocallbacks.Handler, error)
+⋮----
+// NewHandlerFactory returns a cold factory that yields the LangChain LangSmith
+// Eino handler, or (nil, nil) when APIKey is empty so tracing stays off without
+// credentials.
+func NewHandlerFactory(cfg Config) (HandlerFactory, error)
+⋮----
+// HandlerFactoryFromEnv builds a factory from LANGSMITH_API_KEY /
+// LANGSMITH_API_URL. When the API key is unset, returns (nil, nil).
+func HandlerFactoryFromEnv() (HandlerFactory, error)
 </file>
 
 <file path="internal/agents/evaluator/eino/callbacks/callbacks_test.go">
@@ -12068,6 +12294,7 @@ import (
 
 	"github.com/cloudwego/eino/components/tool"
 
+	evaluatormodel "github.com/becker63/searchbench-go/internal/adapters/providers/evaluatormodel"
 	evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
 	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
 	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
@@ -12084,6 +12311,7 @@ import (
 ⋮----
 "github.com/cloudwego/eino/components/tool"
 ⋮----
+evaluatormodel "github.com/becker63/searchbench-go/internal/adapters/providers/evaluatormodel"
 evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
 evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
 "github.com/becker63/searchbench-go/internal/app/round/internal/compare"
@@ -12101,6 +12329,8 @@ type evaluatorExecutor struct {
 // evaluatorAppendix holds manifest-only evaluator text (e.g. systemPrompt).
 ⋮----
 func (e *evaluatorExecutor) Execute(ctx context.Context, spec run.Spec) (run.ExecutedRun, error)
+⋮----
+// Defensive: runComparison normally injects evaluatormodel.NewFactory.
 ⋮----
 func (e *evaluatorExecutor) recordExecution(spec run.Spec, result evaluatoreino.Result)
 ⋮----

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -95,6 +95,16 @@ docs/
 internal/
   adapters/
     backend/
+      iterativecontext/
+        doc.go
+        errors.go
+        factory.go
+        iterativecontext_test.go
+        normalize.go
+        runtime.go
+        session.go
+        toolinfo.go
+        uri.go
       jcodemunch/
         doc.go
         errors.go
@@ -6974,6 +6984,374 @@ Project vocabulary and layering live under **`architecture/`**. Engineering prac
 | [Engineering](engineering/) | Agentic workflow, issue style, testing, pure center |
 
 Read **`AGENTS.md`** at the repository root first; it lists the canonical “start here” paths for contributors and automation.
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/doc.go">
+// Package iterativecontext connects SearchBench evaluator runs to an Iterative Context MCP server.
+//
+// The adapter owns MCP session lifecycle, optional repo root registration, harness-owned
+// score installation ([Runtime.InstallScore], [Runtime.VerifyScore]) before evaluator tools
+// are listed, and MCP tools/call dispatch for evaluator-facing localization tools.
+⋮----
+// Evaluator-visible tool lists intentionally exclude admin/install/verify tools even if the
+// server advertises them in tools/list.
+⋮----
+// Production use starts a subprocess transport via [OpenCommand]. Tests should use [NewRuntime]
+// with an in-memory MCP session from [github.com/modelcontextprotocol/go-sdk/mcp.NewInMemoryTransports].
+package iterativecontext
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/errors.go">
+package iterativecontext
+⋮----
+import (
+	"errors"
+	"fmt"
+)
+⋮----
+"errors"
+"fmt"
+⋮----
+// Kind classifies Iterative Context adapter failures for errors.Is-style checks.
+type Kind int
+⋮----
+const (
+	// KindSession covers MCP transport/session setup before a usable client session exists
+	// (connect, handshake).
+⋮----
+// KindSession covers MCP transport/session setup before a usable client session exists
+// (connect, handshake).
+⋮----
+// KindInstall covers harness score installation via MCP install_score.
+⋮----
+// KindVerify covers harness score verification via MCP verify_score.
+⋮----
+// KindToolSetup covers evaluator tool surface preparation (tools/list and schema mapping).
+⋮----
+// KindToolCall covers evaluator MCP tools/call failures and tool results marked as errors.
+⋮----
+// Error is a typed adapter failure with an operation label.
+type Error struct {
+	Kind Kind
+	Op   string
+	Err  error
+}
+⋮----
+func (e *Error) Error() string
+⋮----
+// Unwrap implements error unwrapper semantics.
+func (e *Error) Unwrap() error
+⋮----
+// IsSession reports whether err is (or wraps) an [Error] with [KindSession].
+func IsSession(err error) bool
+⋮----
+var ie *Error
+⋮----
+// IsInstall reports whether err is (or wraps) an [Error] with [KindInstall].
+func IsInstall(err error) bool
+⋮----
+// IsVerify reports whether err is (or wraps) an [Error] with [KindVerify].
+func IsVerify(err error) bool
+⋮----
+// IsToolSetup reports whether err is (or wraps) an [Error] with [KindToolSetup].
+func IsToolSetup(err error) bool
+⋮----
+// IsToolCall reports whether err is (or wraps) an [Error] with [KindToolCall].
+func IsToolCall(err error) bool
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/factory.go">
+package iterativecontext
+⋮----
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/schema"
+
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+⋮----
+"context"
+"encoding/json"
+"fmt"
+"strings"
+⋮----
+"github.com/cloudwego/eino/components/tool"
+"github.com/cloudwego/eino/schema"
+⋮----
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+⋮----
+// EvaluatorToolFactory returns an [run]-compatible tool factory backed by MCP tools exposed
+// through rt. Only evaluator-safe tools are listed (admin/install/verify tools are omitted).
+func EvaluatorToolFactory(rt *Runtime) func(run.Spec) ([]tool.BaseTool, error)
+⋮----
+var out []tool.BaseTool
+⋮----
+type mcpInvokableTool struct {
+	rt   *Runtime
+	name string
+	info *schema.ToolInfo
+}
+⋮----
+func (t mcpInvokableTool) Info(_ context.Context) (*schema.ToolInfo, error)
+⋮----
+func (t mcpInvokableTool) InvokableRun(ctx context.Context, input string, _ ...tool.Option) (string, error)
+⋮----
+var _ tool.InvokableTool = mcpInvokableTool{}
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/iterativecontext_test.go">
+package iterativecontext_test
+⋮----
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+⋮----
+"context"
+"encoding/json"
+"os/exec"
+"sync"
+"testing"
+"time"
+⋮----
+"github.com/modelcontextprotocol/go-sdk/mcp"
+⋮----
+"github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+⋮----
+func objectSchema() map[string]any
+⋮----
+func TestEvaluatorToolListHidesAdminTools(t *testing.T)
+⋮----
+func TestPrepareScoreInstallBeforeVerify(t *testing.T)
+⋮----
+var mu sync.Mutex
+⋮----
+var args map[string]any
+⋮----
+func TestInstallScoreSurfacesJSONErrorKind(t *testing.T)
+⋮----
+func TestCallToolEvaluatorSurfacesToolKind(t *testing.T)
+⋮----
+func TestOpenCommandFailsSession(t *testing.T)
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/normalize.go">
+package iterativecontext
+⋮----
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+⋮----
+"encoding/json"
+"fmt"
+"strings"
+⋮----
+"github.com/modelcontextprotocol/go-sdk/mcp"
+⋮----
+// NormalizeCallToolResult turns an MCP tools/call result into a single JSON string for Eino.
+//
+// When the result is not an MCP error payload but [mcp.CallToolResult.IsError] is set,
+// this returns an [Error] with [KindToolCall].
+func NormalizeCallToolResult(res *mcp.CallToolResult) (string, error)
+⋮----
+func textFromContent(parts []mcp.Content) string
+⋮----
+var b strings.Builder
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/runtime.go">
+package iterativecontext
+⋮----
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+⋮----
+"context"
+"encoding/json"
+"errors"
+"fmt"
+"strings"
+⋮----
+"github.com/modelcontextprotocol/go-sdk/mcp"
+⋮----
+// Tool names reserved for harness-side score setup; never exposed to the evaluator tool list.
+var excludedEvaluatorToolNames = map[string]struct{}{
+	"install_score": {},
+	"verify_score":  {},
+}
+⋮----
+// ScoreInstallParams selects a policy module on disk and the deterministic identity used by the harness.
+type ScoreInstallParams struct {
+	PolicyPath string
+	PolicyID   string
+	// Symbol names the callable inside the policy module; empty means the server default (score_fn).
+	Symbol string
+}
+⋮----
+// Symbol names the callable inside the policy module; empty means the server default (score_fn).
+⋮----
+// Runtime holds a live MCP client session for Iterative Context tool servers.
+type Runtime struct {
+	session *mcp.ClientSession
+}
+⋮----
+// NewRuntime wraps an initialized MCP client session. The caller must have already
+// completed the MCP initialize handshake (for example via [mcp.Client.Connect]).
+func NewRuntime(session *mcp.ClientSession) *Runtime
+⋮----
+// Session returns the underlying MCP session for advanced call sites.
+func (r *Runtime) Session() *mcp.ClientSession
+⋮----
+// Close ends the MCP session.
+func (r *Runtime) Close() error
+⋮----
+// listMCPTools returns the full paginated tools/list payload from the server.
+func (r *Runtime) listMCPTools(ctx context.Context) ([]*mcp.Tool, error)
+⋮----
+var (
+		all    []*mcp.Tool
+		cursor string
+	)
+⋮----
+// ListEvaluatorTools returns MCP tools intended for the evaluator after stripping harness-admin tools.
+func (r *Runtime) ListEvaluatorTools(ctx context.Context) ([]*mcp.Tool, error)
+⋮----
+var out []*mcp.Tool
+⋮----
+// PrepareScore installs then verifies the active score identity for this MCP session.
+func PrepareScore(ctx context.Context, rt *Runtime, p ScoreInstallParams) error
+⋮----
+// InstallScore invokes MCP install_score for this session.
+func (r *Runtime) InstallScore(ctx context.Context, p ScoreInstallParams) error
+⋮----
+// VerifyScore invokes MCP verify_score for this session.
+func (r *Runtime) VerifyScore(ctx context.Context, policyID string) error
+⋮----
+func (r *Runtime) callAdminTool(ctx context.Context, kind Kind, op, name string, args map[string]any) (string, error)
+⋮----
+var je *Error
+⋮----
+func interpretScoreJSON(kind Kind, op, payloadJSON string) error
+⋮----
+var m map[string]any
+⋮----
+// CallTool invokes MCP tools/call and normalizes the payload for the evaluator tool surface.
+func (r *Runtime) CallTool(ctx context.Context, name string, arguments json.RawMessage) (string, error)
+⋮----
+var args any
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/session.go">
+package iterativecontext
+⋮----
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+⋮----
+"context"
+"fmt"
+"os/exec"
+⋮----
+"github.com/modelcontextprotocol/go-sdk/mcp"
+⋮----
+// CommandConfig starts an MCP server subprocess over stdio and completes the MCP handshake.
+type CommandConfig struct {
+	// Command is the MCP server command (stdin/stdout JSON-RPC). Required.
+	Command *exec.Cmd
+	// RepoPath, when non-empty, is registered as an MCP root before connecting.
+	RepoPath string
+	// Client, when non-empty, is used as the MCP client; otherwise a default SearchBench client is created.
+	Client *mcp.Client
+	// ScoreInstall, when non-nil, runs [PrepareScore] immediately after a successful connect.
+	ScoreInstall *ScoreInstallParams
+}
+⋮----
+// Command is the MCP server command (stdin/stdout JSON-RPC). Required.
+⋮----
+// RepoPath, when non-empty, is registered as an MCP root before connecting.
+⋮----
+// Client, when non-empty, is used as the MCP client; otherwise a default SearchBench client is created.
+⋮----
+// ScoreInstall, when non-nil, runs [PrepareScore] immediately after a successful connect.
+⋮----
+// OpenCommand connects to an Iterative Context MCP server launched as a subprocess.
+func OpenCommand(ctx context.Context, cfg CommandConfig) (*Runtime, error)
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/toolinfo.go">
+package iterativecontext
+⋮----
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudwego/eino/schema"
+	"github.com/eino-contrib/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+⋮----
+"encoding/json"
+"fmt"
+⋮----
+"github.com/cloudwego/eino/schema"
+"github.com/eino-contrib/jsonschema"
+"github.com/modelcontextprotocol/go-sdk/mcp"
+⋮----
+// ToolInfoFromMCP converts an MCP tool definition into Eino [schema.ToolInfo].
+func ToolInfoFromMCP(t *mcp.Tool) (*schema.ToolInfo, error)
+⋮----
+func paramsFromInputSchema(input any) (*schema.ParamsOneOf, error)
+⋮----
+var js jsonschema.Schema
+</file>
+
+<file path="internal/adapters/backend/iterativecontext/uri.go">
+package iterativecontext
+⋮----
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+⋮----
+"fmt"
+"net/url"
+"path/filepath"
+"strings"
+⋮----
+// filePathToRootURI turns a local filesystem path into a file-scheme URI suitable
+// for MCP roots (absolute path, forward slashes in the URI path segment).
+func filePathToRootURI(path string) (string, error)
 </file>
 
 <file path="internal/adapters/backend/jcodemunch/doc.go">


### PR DESCRIPTION
## Summary
Cherry-picked / merged scoped adapter work for **#44**, **#45**, and **#43** onto **integration/adapter-wave-1-review**.

**Note:** Topic branches `adapter/langsmith-callbacks-issue-45` and `adapter/iterative-context-mcp-issue-43` were rooted pre–wave-1; merging them directly would have dropped wave‑1 + submodule. **#44** merged with `--no-ff`; **#45** and **#43** applied via **cherry-pick** with minimal conflict resolution (`evaluator.go` imports + regenerated `repomix-output.xml`).

## Issues
- **#44** — `internal/adapters/providers/evaluatormodel`, default model factory wiring in `internal/app/round/evaluator.go`
- **#45** — `internal/adapters/trace/langsmith`, optional LangSmith callbacks + context labels in evaluator path
- **#43** — `internal/adapters/backend/iterativecontext`, IC MCP session + install/verify score seam + offline tests

## Prerequisites (already on base)
- **#42** gitlink `iterative-context` @ **48b682a**

## Validation (run locally / pre-push)
- `nix develop -c searchbench-go-test-all` — pass
- `nix develop -c searchbench-golangci` — pass
- `nix develop -c searchbench-architecture-check` — pass
- `nix flake check` — pass

## Not in this PR
- **#11** (no branch `adapter/static-graph-localization-score-issue-11` yet)
- **#46 / #47 / #48** — blocked until adapters stable per control plane

Does not close issues until merged or explicitly approved.

Made with [Cursor](https://cursor.com)