### PR TITLE
Implement static localization graph scoring for issue #11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/hmdsefi/gograph v0.7.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	go.uber.org/zap v1.27.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f h1:Z2cODYsUxQPofhpYRMQVwWz4yUVpHF+vPi+eUdruUYI=
 github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f/go.mod h1:JqzWyvTuI2X4+9wOHmKSQCYxybB/8j6Ko43qVmXDuZg=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/smarty/assertions v1.15.0 h1:cR//PqUBUiQRakZWqBiFFQ9wb8emQGDb0HeGdqGByCY=
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=

--- a/internal/adapters/codegraph/treesitter/doc.go
+++ b/internal/adapters/codegraph/treesitter/doc.go
@@ -1,0 +1,7 @@
+// Package treesitter builds SearchBench code graphs from materialized repositories
+// using the tree-sitter Go grammar. Parsing runs in this adapter package; scoring
+// should consume codegraph.Graph only.
+//
+// This package requires CGO (tree-sitter C runtime). With CGO disabled, use the
+// stub implementation that returns [ErrCGODisabled].
+package treesitter

--- a/internal/adapters/codegraph/treesitter/index.go
+++ b/internal/adapters/codegraph/treesitter/index.go
@@ -1,0 +1,240 @@
+//go:build cgo
+
+package treesitter
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+
+// BuildDirectory walks absRepoRoot for *.go sources (skipping dot dirs, vendor,
+// and .git) and returns an in-memory graph with file nodes, function nodes,
+// defines edges, and same-directory call edges resolved by callee identifier name.
+func BuildDirectory(absRepoRoot string) (*codegraph.Store, error) {
+	rootInfo, err := os.Stat(absRepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("treesitter index root: %w", err)
+	}
+	if !rootInfo.IsDir() {
+		return nil, fmt.Errorf("treesitter index root %q is not a directory", absRepoRoot)
+	}
+
+	lang := golang.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	defer parser.Close()
+
+	type fileJob struct {
+		abs  string
+		rel  domain.RepoRelPath
+		data []byte
+	}
+
+	var jobs []fileJob
+	err = filepath.WalkDir(absRepoRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if strings.HasPrefix(base, ".") && base != "." {
+				return filepath.SkipDir
+			}
+			if base == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(path), ".go") {
+			return nil
+		}
+		relPath, err := filepath.Rel(absRepoRoot, path)
+		if err != nil {
+			return err
+		}
+		repoRel := domain.CanonicalizePath(filepath.ToSlash(relPath))
+		if repoRel == "" {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		jobs = append(jobs, fileJob{abs: path, rel: repoRel, data: b})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dirKey := func(absFile string) string { return filepath.Clean(filepath.Dir(absFile)) }
+
+	type dirSyms struct {
+		funcs map[string]codegraph.NodeID
+	}
+	dirFuncs := make(map[string]*dirSyms)
+
+	for _, job := range jobs {
+		dk := dirKey(job.abs)
+		if dirFuncs[dk] == nil {
+			dirFuncs[dk] = &dirSyms{funcs: make(map[string]codegraph.NodeID)}
+		}
+		tree, err := parser.ParseCtx(context.Background(), nil, job.data)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", job.rel, err)
+		}
+		root := tree.RootNode()
+		if root.HasError() {
+			continue
+		}
+		collectFuncSymbols(*root, job.data, job.rel, dirFuncs[dk].funcs)
+	}
+
+	store := codegraph.NewStore()
+	addedFiles := make(map[domain.RepoRelPath]struct{})
+
+	for _, job := range jobs {
+		tree, err := parser.ParseCtx(context.Background(), nil, job.data)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", job.rel, err)
+		}
+		root := tree.RootNode()
+		if root.HasError() {
+			continue
+		}
+		sym := dirFuncs[dirKey(job.abs)].funcs
+		if err := materializeFile(store, addedFiles, *root, job.data, job.rel, sym); err != nil {
+			return nil, err
+		}
+	}
+
+	return store, nil
+}
+
+func collectFuncSymbols(n sitter.Node, src []byte, file domain.RepoRelPath, out map[string]codegraph.NodeID) {
+	switch n.Type() {
+	case "function_declaration", "method_declaration":
+		id := declFuncID(n, src, file)
+		if id == "" {
+			break
+		}
+		name := declName(n, src)
+		if name != "" {
+			out[name] = id
+		}
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ch := n.NamedChild(i)
+		if ch != nil {
+			collectFuncSymbols(*ch, src, file, out)
+		}
+	}
+}
+
+func materializeFile(store *codegraph.Store, addedFiles map[domain.RepoRelPath]struct{}, root sitter.Node, src []byte, file domain.RepoRelPath, sym map[string]codegraph.NodeID) error {
+	fileID := codegraph.NodeID("file:" + string(file))
+	if _, ok := addedFiles[file]; !ok {
+		if err := store.AddNode(codegraph.NewFileNode(fileID, file)); err != nil {
+			return err
+		}
+		addedFiles[file] = struct{}{}
+	}
+
+	var walkErr error
+	var walk func(sitter.Node)
+	walk = func(n sitter.Node) {
+		if walkErr != nil {
+			return
+		}
+		switch n.Type() {
+		case "function_declaration", "method_declaration":
+			id := declFuncID(n, src, file)
+			if id == "" {
+				break
+			}
+			fn := buildFuncNode(n, src, file, id)
+			if err := store.AddNode(fn); err != nil {
+				walkErr = err
+				return
+			}
+			if err := store.AddEdge(codegraph.NewEdge(fileID, id, codegraph.EdgeDefines)); err != nil {
+				walkErr = err
+				return
+			}
+			if body := n.ChildByFieldName("body"); body != nil {
+				scanCalls(store, *body, src, id, sym)
+			}
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			ch := n.NamedChild(i)
+			if ch != nil {
+				walk(*ch)
+			}
+		}
+	}
+	walk(root)
+	return walkErr
+}
+
+func scanCalls(store *codegraph.Store, n sitter.Node, src []byte, caller codegraph.NodeID, sym map[string]codegraph.NodeID) {
+	if n.Type() == "call_expression" {
+		if fun := n.ChildByFieldName("function"); fun != nil && fun.Type() == "identifier" {
+			name := strings.TrimSpace(fun.Content(src))
+			if callee, ok := sym[name]; ok && callee != caller {
+				_ = store.AddEdge(codegraph.NewEdge(caller, callee, codegraph.EdgeCalls))
+			}
+		}
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ch := n.NamedChild(i)
+		if ch != nil {
+			scanCalls(store, *ch, src, caller, sym)
+		}
+	}
+}
+
+func declName(n sitter.Node, src []byte) string {
+	name := n.ChildByFieldName("name")
+	if name == nil {
+		return ""
+	}
+	return strings.TrimSpace(name.Content(src))
+}
+
+func declFuncID(n sitter.Node, src []byte, file domain.RepoRelPath) codegraph.NodeID {
+	name := n.ChildByFieldName("name")
+	if name == nil {
+		return ""
+	}
+	nm := strings.TrimSpace(name.Content(src))
+	if nm == "" {
+		return ""
+	}
+	line := int(name.StartPoint().Row) + 1
+	return codegraph.NodeID(fmt.Sprintf("fn:%s:%s:%d", file, nm, line))
+}
+
+func buildFuncNode(decl sitter.Node, src []byte, file domain.RepoRelPath, id codegraph.NodeID) codegraph.Node {
+	name := declName(decl, src)
+	start := 1
+	end := 1
+	if nn := decl.ChildByFieldName("name"); nn != nil {
+		start = int(nn.StartPoint().Row) + 1
+		end = start
+	}
+	if body := decl.ChildByFieldName("body"); body != nil {
+		end = int(body.EndPoint().Row) + 1
+	}
+	return codegraph.NewFunctionNode(id, file, name, start, end)
+}

--- a/internal/adapters/codegraph/treesitter/index_test.go
+++ b/internal/adapters/codegraph/treesitter/index_test.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+package treesitter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/becker63/searchbench-go/internal/adapters/codegraph/treesitter"
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+
+func TestBuildDirectory_threeFileChain(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "pred.go"), `package p
+
+func PredRoot() {
+	Mid()
+}
+`)
+	writeFile(t, filepath.Join(dir, "mid.go"), `package p
+
+func Mid() {
+	GoldLeaf()
+}
+`)
+	writeFile(t, filepath.Join(dir, "gold.go"), `package p
+
+func GoldLeaf() {}
+`)
+
+	store, err := treesitter.BuildDirectory(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := store.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pred := domain.CanonicalizePath("pred.go")
+	gold := domain.CanonicalizePath("gold.go")
+
+	hops, ok := codegraph.MinCallHopsAcrossFiles(g, []domain.RepoRelPath{pred}, []domain.RepoRelPath{gold})
+	if !ok {
+		t.Fatal("expected localization hops across pred and gold files")
+	}
+	if hops != 2 {
+		t.Fatalf("expected hop count 2 (PredRoot→Mid→GoldLeaf), got %d", hops)
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/adapters/codegraph/treesitter/stub.go
+++ b/internal/adapters/codegraph/treesitter/stub.go
@@ -1,0 +1,17 @@
+//go:build !cgo
+
+package treesitter
+
+import (
+	"errors"
+
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+)
+
+// ErrCGODisabled indicates the tree-sitter indexer was compiled without CGO.
+var ErrCGODisabled = errors.New("codegraph/treesitter: tree-sitter indexer requires CGO_ENABLED=1")
+
+// BuildDirectory is unavailable without CGO.
+func BuildDirectory(absRepoRoot string) (*codegraph.Store, error) {
+	return nil, ErrCGODisabled
+}

--- a/internal/pure/codegraph/localdistance.go
+++ b/internal/pure/codegraph/localdistance.go
@@ -1,0 +1,60 @@
+package codegraph
+
+import (
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+
+// MinCallHopsAcrossFiles reports the smallest shortest-path hop count between any
+// function node anchored in fromFiles and any function node anchored in toFiles,
+// considering only directed EdgeCalls edges.
+//
+// Files are matched via Node.RepoFile; only NodeFunction kinds participate.
+// If either side has no function nodes in those files, it returns ok=false.
+func MinCallHopsAcrossFiles(g Graph, fromFiles, toFiles []domain.RepoRelPath) (hops int, ok bool) {
+	filter := EdgeFilter{Kinds: []EdgeKind{EdgeCalls}}
+
+	fromIDs := functionNodesInFiles(g, fromFiles)
+	toIDs := functionNodesInFiles(g, toFiles)
+	if len(fromIDs) == 0 || len(toIDs) == 0 {
+		return 0, false
+	}
+
+	best := 0
+	found := false
+	for _, a := range fromIDs {
+		for _, b := range toIDs {
+			if a == b {
+				continue
+			}
+			p, okp := g.ShortestPath(a, b, filter)
+			if !okp || len(p.Nodes) == 0 {
+				continue
+			}
+			h := p.Hops()
+			if !found || h < best {
+				best = h
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func functionNodesInFiles(g Graph, files []domain.RepoRelPath) []NodeID {
+	seen := make(map[domain.RepoRelPath]struct{}, len(files))
+	for _, f := range files {
+		seen[f] = struct{}{}
+	}
+
+	var out []NodeID
+	for file := range seen {
+		for _, id := range g.NodesByFile(file) {
+			n, ok := g.Node(id)
+			if !ok || n.Kind != NodeFunction {
+				continue
+			}
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/internal/pure/codegraph/localdistance_test.go
+++ b/internal/pure/codegraph/localdistance_test.go
@@ -1,0 +1,53 @@
+package codegraph_test
+
+import (
+	"testing"
+
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+
+func TestMinCallHopsAcrossFiles_twoFiles(t *testing.T) {
+	a := domain.CanonicalizePath("a.go")
+	b := domain.CanonicalizePath("b.go")
+	c := domain.CanonicalizePath("c.go")
+	store := codegraph.NewStore()
+
+	fa := codegraph.NewFileNode(codegraph.NodeID("file:a.go"), a)
+	fb := codegraph.NewFileNode(codegraph.NodeID("file:b.go"), b)
+	fc := codegraph.NewFileNode(codegraph.NodeID("file:c.go"), c)
+	x := codegraph.NewFunctionNode(codegraph.NodeID("fn:a.go:X:1"), a, "X", 1, 2)
+	y := codegraph.NewFunctionNode(codegraph.NodeID("fn:c.go:Y:1"), c, "Y", 1, 2)
+	z := codegraph.NewFunctionNode(codegraph.NodeID("fn:b.go:Z:1"), b, "Z", 1, 2)
+
+	for _, err := range []error{
+		store.AddNode(fa),
+		store.AddNode(fb),
+		store.AddNode(fc),
+		store.AddNode(x),
+		store.AddNode(y),
+		store.AddNode(z),
+		store.AddEdge(codegraph.NewEdge(fa.ID, x.ID, codegraph.EdgeDefines)),
+		store.AddEdge(codegraph.NewEdge(fc.ID, y.ID, codegraph.EdgeDefines)),
+		store.AddEdge(codegraph.NewEdge(fb.ID, z.ID, codegraph.EdgeDefines)),
+		store.AddEdge(codegraph.NewEdge(x.ID, y.ID, codegraph.EdgeCalls)),
+		store.AddEdge(codegraph.NewEdge(y.ID, z.ID, codegraph.EdgeCalls)),
+	} {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	g, err := store.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hops, ok := codegraph.MinCallHopsAcrossFiles(g, []domain.RepoRelPath{a}, []domain.RepoRelPath{b})
+	if !ok {
+		t.Fatal("expected hops across files")
+	}
+	if hops != 2 {
+		t.Fatalf("expected 2 hops X→Y→Z, got %d", hops)
+	}
+}

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -126,6 +126,12 @@ internal/
         serialize.go
         writer_test.go
         writer.go
+    codegraph/
+      treesitter/
+        doc.go
+        index_test.go
+        index.go
+        stub.go
     config/
       pkl/
         doc.go
@@ -282,6 +288,8 @@ internal/
       doc.go
       edge.go
       graph.go
+      localdistance_test.go
+      localdistance.go
       node.go
       path.go
       store.go
@@ -8181,6 +8189,132 @@ func safeBundleName(name string) bool
 func hasCompleteMarker(dir string) bool
 </file>
 
+<file path="internal/adapters/codegraph/treesitter/doc.go">
+// Package treesitter builds SearchBench code graphs from materialized repositories
+// using the tree-sitter Go grammar. Parsing runs in this adapter package; scoring
+// should consume codegraph.Graph only.
+//
+// This package requires CGO (tree-sitter C runtime). With CGO disabled, use the
+// stub implementation that returns [ErrCGODisabled].
+package treesitter
+</file>
+
+<file path="internal/adapters/codegraph/treesitter/index_test.go">
+//go:build cgo
+⋮----
+package treesitter_test
+⋮----
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/becker63/searchbench-go/internal/adapters/codegraph/treesitter"
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+⋮----
+"os"
+"path/filepath"
+"testing"
+⋮----
+"github.com/becker63/searchbench-go/internal/adapters/codegraph/treesitter"
+"github.com/becker63/searchbench-go/internal/pure/codegraph"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+⋮----
+func TestBuildDirectory_threeFileChain(t *testing.T)
+⋮----
+func writeFile(t *testing.T, path, body string)
+</file>
+
+<file path="internal/adapters/codegraph/treesitter/index.go">
+//go:build cgo
+⋮----
+package treesitter
+⋮----
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+⋮----
+"context"
+"fmt"
+"io/fs"
+"os"
+"path/filepath"
+"strings"
+⋮----
+sitter "github.com/smacker/go-tree-sitter"
+"github.com/smacker/go-tree-sitter/golang"
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/codegraph"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+⋮----
+// BuildDirectory walks absRepoRoot for *.go sources (skipping dot dirs, vendor,
+// and .git) and returns an in-memory graph with file nodes, function nodes,
+// defines edges, and same-directory call edges resolved by callee identifier name.
+func BuildDirectory(absRepoRoot string) (*codegraph.Store, error)
+⋮----
+type fileJob struct {
+		abs  string
+		rel  domain.RepoRelPath
+		data []byte
+	}
+⋮----
+var jobs []fileJob
+⋮----
+type dirSyms struct {
+		funcs map[string]codegraph.NodeID
+	}
+⋮----
+func collectFuncSymbols(n sitter.Node, src []byte, file domain.RepoRelPath, out map[string]codegraph.NodeID)
+⋮----
+func materializeFile(store *codegraph.Store, addedFiles map[domain.RepoRelPath]struct
+⋮----
+var walkErr error
+var walk func(sitter.Node)
+⋮----
+func scanCalls(store *codegraph.Store, n sitter.Node, src []byte, caller codegraph.NodeID, sym map[string]codegraph.NodeID)
+⋮----
+func declName(n sitter.Node, src []byte) string
+⋮----
+func declFuncID(n sitter.Node, src []byte, file domain.RepoRelPath) codegraph.NodeID
+⋮----
+func buildFuncNode(decl sitter.Node, src []byte, file domain.RepoRelPath, id codegraph.NodeID) codegraph.Node
+</file>
+
+<file path="internal/adapters/codegraph/treesitter/stub.go">
+//go:build !cgo
+⋮----
+package treesitter
+⋮----
+import (
+	"errors"
+
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+)
+⋮----
+"errors"
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/codegraph"
+⋮----
+// ErrCGODisabled indicates the tree-sitter indexer was compiled without CGO.
+var ErrCGODisabled = errors.New("codegraph/treesitter: tree-sitter indexer requires CGO_ENABLED=1")
+⋮----
+// BuildDirectory is unavailable without CGO.
+func BuildDirectory(absRepoRoot string) (*codegraph.Store, error)
+</file>
+
 <file path="internal/adapters/config/pkl/doc.go">
 // Package config owns the Pkl-backed round manifest surface.
 //
@@ -13344,6 +13478,46 @@ type Graph interface {
 }
 </file>
 
+<file path="internal/pure/codegraph/localdistance_test.go">
+package codegraph_test
+⋮----
+import (
+	"testing"
+
+	"github.com/becker63/searchbench-go/internal/pure/codegraph"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+⋮----
+"testing"
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/codegraph"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+⋮----
+func TestMinCallHopsAcrossFiles_twoFiles(t *testing.T)
+</file>
+
+<file path="internal/pure/codegraph/localdistance.go">
+package codegraph
+⋮----
+import (
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+)
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/domain"
+⋮----
+// MinCallHopsAcrossFiles reports the smallest shortest-path hop count between any
+// function node anchored in fromFiles and any function node anchored in toFiles,
+// considering only directed EdgeCalls edges.
+//
+// Files are matched via Node.RepoFile; only NodeFunction kinds participate.
+// If either side has no function nodes in those files, it returns ok=false.
+func MinCallHopsAcrossFiles(g Graph, fromFiles, toFiles []domain.RepoRelPath) (hops int, ok bool)
+⋮----
+func functionNodesInFiles(g Graph, files []domain.RepoRelPath) []NodeID
+⋮----
+var out []NodeID
+</file>
+
 <file path="internal/pure/codegraph/node.go">
 package codegraph
 ⋮----
@@ -18056,6 +18230,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/hmdsefi/gograph v0.7.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	go.uber.org/zap v1.27.1
 )
 


### PR DESCRIPTION
Implements **#11** on merged adapter/provider/backend base (`main` @ wave 1+2).

### What
- `internal/adapters/codegraph/treesitter`: tree-sitter Go indexer over a materialized repo root → `codegraph.Store` (file + function nodes, `defines` + same-directory `calls` edges). **CGO** implementation + **!cgo** stub (`ErrCGODisabled`).
- `internal/pure/codegraph/localdistance.go`: `MinCallHopsAcrossFiles` over **EdgeCalls** only (deterministic shortest hops between function nodes anchored in two path sets).

### Tests
- Pure distance unit test (manual graph).
- CGO integration test: three-file `PredRoot → Mid → GoldLeaf` chain.

### Validation
- `go test ./...`
- `nix develop -c golangci-lint run ./...`
- Pre-push hooks (incl. architecture import boundaries)

Refs #11

Made with [Cursor](https://cursor.com)