### PR TITLE
Wire evaluator runtime across prepared backend tools for issue #46

### DIFF
--- a/internal/app/round/evaluator.go
+++ b/internal/app/round/evaluator.go
@@ -37,7 +37,7 @@ func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (r
 
 	executor := &evaluatorExecutor{
 		modelFactory: modelFactory,
-		toolFactory:  request.EvaluatorToolFactory,
+		toolFactory:  resolvePreparedToolFactory(request),
 		allowedTools: allowedTools,
 		evaluatorAppendix: run.EvaluatorRunAppendix{
 			SystemPrompt: plan.Evaluator.ToolPolicy.SystemPrompt,
@@ -77,7 +77,7 @@ func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (r
 
 type evaluatorExecutor struct {
 	modelFactory EvaluatorModelFactory
-	toolFactory  EvaluatorToolFactory
+	toolFactory  preparedToolFactory
 	allowedTools map[string]struct{}
 	// evaluatorAppendix holds manifest-only evaluator text (e.g. systemPrompt).
 	evaluatorAppendix run.EvaluatorRunAppendix
@@ -102,9 +102,12 @@ func (e *evaluatorExecutor) Execute(ctx context.Context, spec run.Spec) (run.Exe
 
 	toolFactory := e.toolFactory
 	if toolFactory == nil {
-		toolFactory = evaluatorfake.ToolFactory
+		toolFactory = wrapLegacyEvaluatorToolFactory(evaluatorfake.ToolFactory)
 	}
-	tools, err := toolFactory(spec)
+	tools, cleanup, err := toolFactory(ctx, spec)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		return run.ExecutedRun{}, fmt.Errorf("local evaluator tools: %w", err)
 	}

--- a/internal/app/round/evaluator_runtime_test.go
+++ b/internal/app/round/evaluator_runtime_test.go
@@ -1,0 +1,229 @@
+package round
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	iterativecontext "github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+	evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
+	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+
+func TestDefaultPreparedTools_selectsFakeBackend(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	spec := testEvaluatorSpec(t, domain.BackendFake, nil)
+	tools, cleanup, err := defaultPreparedToolFactory()(ctx, spec)
+	if cleanup != nil {
+		t.Fatal("expected nil cleanup for fake backend")
+	}
+	if err != nil {
+		t.Fatalf("tool factory: %v", err)
+	}
+	if len(tools) != len(evaluatorfake.LocalEvaluatorToolNames()) {
+		t.Fatalf("tools len %d, want %d", len(tools), len(evaluatorfake.LocalEvaluatorToolNames()))
+	}
+}
+
+func TestDefaultPreparedTools_jCodeMunchRequiresEnv(t *testing.T) {
+	t.Setenv(envJCodeMunchCommand, "")
+	ctx := context.Background()
+	spec := testEvaluatorSpec(t, domain.BackendJCodeMunch, nil)
+	_, _, err := defaultPreparedToolFactory()(ctx, spec)
+	if err == nil {
+		t.Fatal("expected error when jCodeMunch command env is unset")
+	}
+}
+
+func TestDefaultPreparedTools_iterativeContextRequiresPolicy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	spec := testEvaluatorSpec(t, domain.BackendIterativeContext, nil)
+	_, _, err := defaultPreparedToolFactory()(ctx, spec)
+	if err == nil {
+		t.Fatal("expected error without policy")
+	}
+}
+
+func TestDefaultPreparedTools_iterativeContextRequiresEnv(t *testing.T) {
+	t.Setenv(envIterativeContextCommand, "")
+	ctx := context.Background()
+	pol := domain.NewPythonPolicy(domain.PolicyID("p1"), "def score_fn(x):\n    return []\n", "score_fn")
+	spec := testEvaluatorSpec(t, domain.BackendIterativeContext, &pol)
+	_, cleanup, err := defaultPreparedToolFactory()(ctx, spec)
+	if cleanup != nil {
+		cleanup()
+		t.Fatal("unexpected cleanup")
+	}
+	if err == nil {
+		t.Fatal("expected error when Iterative Context command env is unset")
+	}
+}
+
+func TestEvaluatorExecutor_fakeBackendUsesDefaultPreparedTools(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	spec := testEvaluatorSpec(t, domain.BackendFake, nil)
+
+	allowed := map[string]struct{}{}
+	for _, name := range evaluatorfake.LocalEvaluatorDefaultAllowedToolNames() {
+		allowed[name] = struct{}{}
+	}
+
+	ex := &evaluatorExecutor{
+		modelFactory:      evaluatorfake.ModelFactory,
+		toolFactory:       defaultPreparedToolFactory(),
+		allowedTools:      allowed,
+		retryPolicy:       evaluatoreino.RetryPolicy{MaxAttempts: 1},
+		evaluatorAppendix: run.EvaluatorRunAppendix{},
+	}
+	executed, err := ex.Execute(ctx, spec)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(executed.Prediction.Files) == 0 {
+		t.Fatalf("expected prediction files")
+	}
+
+	recs := ex.executions()
+	if len(recs) != 1 {
+		t.Fatalf("execution records len %d", len(recs))
+	}
+	if len(recs[0].Result.Phases) == 0 {
+		t.Fatal("expected evaluator phases on success path")
+	}
+}
+
+func TestEvaluatorExecutor_toolFactoryErrorSkipsEvaluatorRun(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	spec := testEvaluatorSpec(t, domain.BackendFake, nil)
+	allowed := map[string]struct{}{}
+	for _, name := range evaluatorfake.LocalEvaluatorDefaultAllowedToolNames() {
+		allowed[name] = struct{}{}
+	}
+	ex := &evaluatorExecutor{
+		modelFactory: evaluatorfake.ModelFactory,
+		toolFactory: func(context.Context, run.Spec) ([]tool.BaseTool, func(), error) {
+			return nil, nil, fmt.Errorf("injected tool factory failure")
+		},
+		allowedTools: allowed,
+		retryPolicy:  evaluatoreino.RetryPolicy{MaxAttempts: 1},
+	}
+	_, err := ex.Execute(ctx, spec)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(ex.executions()) != 0 {
+		t.Fatal("expected no recorded executions when tool preparation fails")
+	}
+}
+
+func TestIterativeContextEvaluatorToolSurfaceOmitsAdminTools(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	impl := &mcp.Implementation{Name: "ic-round-test", Version: "v0"}
+	server := mcp.NewServer(impl, nil)
+	obj := map[string]any{"type": "object"}
+	server.AddTool(&mcp.Tool{Name: "resolve", Description: "r", InputSchema: obj},
+		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"ok": true}}, nil
+		})
+	server.AddTool(&mcp.Tool{Name: "install_score", Description: "a", InputSchema: obj},
+		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{StructuredContent: map[string]any{"ok": true}}, nil
+		})
+
+	st, ct := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	client := mcp.NewClient(impl, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	rt := iterativecontext.NewRuntime(cs)
+	factory := iterativecontext.EvaluatorToolFactory(rt)
+	tools, err := factory(run.Spec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tl := range tools {
+		info, ierr := tl.Info(ctx)
+		if ierr != nil {
+			t.Fatal(ierr)
+		}
+		switch info.Name {
+		case "install_score", "verify_score":
+			t.Fatalf("admin tool %q leaked to evaluator-visible factory", info.Name)
+		}
+	}
+}
+
+func TestLegacyToolFactoryWrapperPassesThrough(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	spec := testEvaluatorSpec(t, domain.BackendFake, nil)
+	called := false
+	wrapped := wrapLegacyEvaluatorToolFactory(func(s run.Spec) ([]tool.BaseTool, error) {
+		called = true
+		if s.ID != spec.ID {
+			t.Fatalf("spec id mismatch")
+		}
+		return evaluatorfake.ToolFactory(s)
+	})
+	tools, cleanup, err := wrapped(ctx, spec)
+	if cleanup != nil {
+		t.Fatal("expected nil cleanup")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("expected legacy factory invoked")
+	}
+	if len(tools) == 0 {
+		t.Fatal("expected tools")
+	}
+}
+
+func testEvaluatorSpec(t *testing.T, backend domain.BackendKind, policy *domain.PolicyArtifact) run.Spec {
+	t.Helper()
+	dir := t.TempDir()
+	sys := domain.SystemSpec{
+		ID:           domain.SystemID("sys-1"),
+		Name:         "test-system",
+		Backend:      backend,
+		Model:        domain.ModelSpec{Provider: "fake", Name: "fake"},
+		PromptBundle: domain.PromptBundleRef{Name: "default"},
+		Policy:       policy,
+	}
+	if err := sys.Validate(); err != nil {
+		t.Fatalf("system validate: %v", err)
+	}
+	match := domain.MatchSpec{
+		ID:        domain.MatchID("match-1"),
+		Benchmark: domain.BenchmarkLCA,
+		Repo: domain.RepoSnapshot{
+			Name: "demo/repo",
+			Path: domain.HostPath(dir),
+		},
+		Input: domain.MatchInput{Title: "locate bug"},
+		Oracle: domain.MatchOracle{
+			GoldFiles: []domain.RepoRelPath{"src/search_target.go"},
+		},
+	}
+	return run.NewSpec(domain.RunID("incumbent-match-1-sys"), match, sys)
+}

--- a/internal/app/round/prepared_tools.go
+++ b/internal/app/round/prepared_tools.go
@@ -1,0 +1,144 @@
+package round
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cloudwego/eino/components/tool"
+
+	iterativecontext "github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+	jcodemunch "github.com/becker63/searchbench-go/internal/adapters/backend/jcodemunch"
+	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+
+// Environment variables name MCP server launch commands (stdin/stdout JSON-RPC).
+// Values are executed as `sh -c <value>` so quoting behaves like a shell command line.
+const (
+	envJCodeMunchCommand       = "SEARCHBENCH_JCODEMUNCH_COMMAND"
+	envIterativeContextCommand = "SEARCHBENCH_ITERATIVE_CONTEXT_COMMAND"
+)
+
+// preparedToolFactory builds evaluator tools for one spec and returns an optional
+// cleanup callback once the evaluator run finishes (MCP sessions, temp policy files).
+type preparedToolFactory func(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error)
+
+func wrapLegacyEvaluatorToolFactory(f EvaluatorToolFactory) preparedToolFactory {
+	if f == nil {
+		return nil
+	}
+	return func(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error) {
+		tools, err := f(spec)
+		return tools, nil, err
+	}
+}
+
+func defaultPreparedToolFactory() preparedToolFactory {
+	return func(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error) {
+		switch spec.System.Backend {
+		case domain.BackendFake:
+			tools, err := evaluatorfake.ToolFactory(spec)
+			return tools, nil, err
+		case domain.BackendJCodeMunch:
+			return openJCodeMunchTools(ctx, spec)
+		case domain.BackendIterativeContext:
+			return openIterativeContextTools(ctx, spec)
+		default:
+			return nil, nil, fmt.Errorf("unsupported backend %q for default evaluator tools", spec.System.Backend)
+		}
+	}
+}
+
+func resolvePreparedToolFactory(req evaluationRequest) preparedToolFactory {
+	if req.EvaluatorToolFactory != nil {
+		return wrapLegacyEvaluatorToolFactory(req.EvaluatorToolFactory)
+	}
+	return defaultPreparedToolFactory()
+}
+
+func openJCodeMunchTools(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error) {
+	line := strings.TrimSpace(os.Getenv(envJCodeMunchCommand))
+	if line == "" {
+		return nil, nil, fmt.Errorf("%s must be set to launch the jCodeMunch MCP server for backend %q",
+			envJCodeMunchCommand, spec.System.Backend)
+	}
+	cmd := exec.CommandContext(ctx, "sh", "-c", line)
+	rt, err := jcodemunch.OpenCommand(ctx, jcodemunch.CommandConfig{
+		Command:  cmd,
+		RepoPath: strings.TrimSpace(string(spec.Match.Repo.Path)),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	tools, ferr := jcodemunch.EvaluatorToolFactory(rt)(spec)
+	if ferr != nil {
+		_ = rt.Close()
+		return nil, nil, ferr
+	}
+	return tools, func() { _ = rt.Close() }, nil
+}
+
+func openIterativeContextTools(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error) {
+	if spec.System.Policy == nil {
+		return nil, nil, fmt.Errorf("iterative-context backend requires system.policy for score preparation")
+	}
+	line := strings.TrimSpace(os.Getenv(envIterativeContextCommand))
+	if line == "" {
+		return nil, nil, fmt.Errorf("%s must be set to launch the Iterative Context MCP server for backend %q",
+			envIterativeContextCommand, spec.System.Backend)
+	}
+	policyPath, removePolicy, err := writePolicyTempFile(spec.System.Policy)
+	if err != nil {
+		return nil, nil, fmt.Errorf("write temporary policy file: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "sh", "-c", line)
+	symbol := strings.TrimSpace(spec.System.Policy.Entrypoint)
+	install := iterativecontext.ScoreInstallParams{
+		PolicyPath: policyPath,
+		PolicyID:   spec.System.Policy.ID.String(),
+		Symbol:     symbol,
+	}
+	rt, err := iterativecontext.OpenCommand(ctx, iterativecontext.CommandConfig{
+		Command:      cmd,
+		RepoPath:     strings.TrimSpace(string(spec.Match.Repo.Path)),
+		ScoreInstall: &install,
+	})
+	if err != nil {
+		removePolicy()
+		return nil, nil, err
+	}
+	tools, ferr := iterativecontext.EvaluatorToolFactory(rt)(spec)
+	if ferr != nil {
+		_ = rt.Close()
+		removePolicy()
+		return nil, nil, ferr
+	}
+	cleanup := func() {
+		_ = rt.Close()
+		removePolicy()
+	}
+	return tools, cleanup, nil
+}
+
+func writePolicyTempFile(p *domain.PolicyArtifact) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "searchbench-ic-policy-*.py")
+	if err != nil {
+		return "", nil, err
+	}
+	path = f.Name()
+	cleanup = func() { _ = os.Remove(path) }
+	if _, err := f.WriteString(p.Source); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return path, cleanup, nil
+}

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -261,9 +261,11 @@ internal/
       evaluation_resolve.go
       evaluation_test.go
       evaluation_types.go
+      evaluator_runtime_test.go
       evaluator.go
       example_fixtures_test.go
       match_source.go
+      prepared_tools.go
       run_test.go
       run.go
       types.go
@@ -12794,6 +12796,56 @@ type Result struct {
 }
 </file>
 
+<file path="internal/app/round/evaluator_runtime_test.go">
+package round
+⋮----
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	iterativecontext "github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+	evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
+	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+⋮----
+"context"
+"fmt"
+"testing"
+⋮----
+"github.com/cloudwego/eino/components/tool"
+"github.com/modelcontextprotocol/go-sdk/mcp"
+⋮----
+iterativecontext "github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+evaluatoreino "github.com/becker63/searchbench-go/internal/agents/evaluator/eino"
+evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+⋮----
+func TestDefaultPreparedTools_selectsFakeBackend(t *testing.T)
+⋮----
+func TestDefaultPreparedTools_jCodeMunchRequiresEnv(t *testing.T)
+⋮----
+func TestDefaultPreparedTools_iterativeContextRequiresPolicy(t *testing.T)
+⋮----
+func TestDefaultPreparedTools_iterativeContextRequiresEnv(t *testing.T)
+⋮----
+func TestEvaluatorExecutor_fakeBackendUsesDefaultPreparedTools(t *testing.T)
+⋮----
+func TestEvaluatorExecutor_toolFactoryErrorSkipsEvaluatorRun(t *testing.T)
+⋮----
+func TestIterativeContextEvaluatorToolSurfaceOmitsAdminTools(t *testing.T)
+⋮----
+func TestLegacyToolFactoryWrapperPassesThrough(t *testing.T)
+⋮----
+func testEvaluatorSpec(t *testing.T, backend domain.BackendKind, policy *domain.PolicyArtifact) run.Spec
+</file>
+
 <file path="internal/app/round/evaluator.go">
 package round
 ⋮----
@@ -12839,7 +12891,7 @@ func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (r
 ⋮----
 type evaluatorExecutor struct {
 	modelFactory EvaluatorModelFactory
-	toolFactory  EvaluatorToolFactory
+	toolFactory  preparedToolFactory
 	allowedTools map[string]struct{}
 ⋮----
 // evaluatorAppendix holds manifest-only evaluator text (e.g. systemPrompt).
@@ -12924,6 +12976,63 @@ type compositeMatchSource struct {
 func newDefaultMatchSource() dataset.MatchSource
 ⋮----
 func (c compositeMatchSource) Matches(ctx context.Context, req dataset.Request) (domain.NonEmpty[domain.MatchSpec], error)
+</file>
+
+<file path="internal/app/round/prepared_tools.go">
+package round
+⋮----
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cloudwego/eino/components/tool"
+
+	iterativecontext "github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+	jcodemunch "github.com/becker63/searchbench-go/internal/adapters/backend/jcodemunch"
+	evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+)
+⋮----
+"context"
+"fmt"
+"os"
+"os/exec"
+"strings"
+⋮----
+"github.com/cloudwego/eino/components/tool"
+⋮----
+iterativecontext "github.com/becker63/searchbench-go/internal/adapters/backend/iterativecontext"
+jcodemunch "github.com/becker63/searchbench-go/internal/adapters/backend/jcodemunch"
+evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+⋮----
+// Environment variables name MCP server launch commands (stdin/stdout JSON-RPC).
+// Values are executed as `sh -c <value>` so quoting behaves like a shell command line.
+const (
+	envJCodeMunchCommand       = "SEARCHBENCH_JCODEMUNCH_COMMAND"
+	envIterativeContextCommand = "SEARCHBENCH_ITERATIVE_CONTEXT_COMMAND"
+)
+⋮----
+// preparedToolFactory builds evaluator tools for one spec and returns an optional
+// cleanup callback once the evaluator run finishes (MCP sessions, temp policy files).
+type preparedToolFactory func(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error)
+⋮----
+func wrapLegacyEvaluatorToolFactory(f EvaluatorToolFactory) preparedToolFactory
+⋮----
+func defaultPreparedToolFactory() preparedToolFactory
+⋮----
+func resolvePreparedToolFactory(req evaluationRequest) preparedToolFactory
+⋮----
+func openJCodeMunchTools(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error)
+⋮----
+func openIterativeContextTools(ctx context.Context, spec run.Spec) ([]tool.BaseTool, func(), error)
+⋮----
+func writePolicyTempFile(p *domain.PolicyArtifact) (path string, cleanup func(), err error)
 </file>
 
 <file path="internal/app/round/run_test.go">


### PR DESCRIPTION
Implements #46 using the merged backend/provider/trace adapter seams.

## Summary
- Default evaluator tool preparation selects **jcodemunch**, **iterative-context**, or **fake** from `spec.System.Backend` when no explicit `EvaluatorToolFactory` is injected.
- Real MCP backends require env-launched servers: `SEARCHBENCH_JCODEMUNCH_COMMAND` and `SEARCHBENCH_ITERATIVE_CONTEXT_COMMAND` (shell lines via `sh -c`).
- Iterative Context opens via adapter `OpenCommand` with `ScoreInstall` (policy written to a temp file); MCP runtime and temp file are closed/removed after each evaluator run.
- Legacy `EvaluatorToolFactory` injection unchanged (no cleanup hook).

Does **not** implement #47 round match execution or #48 localization evidence.

## Validation
- `go test ./internal/app/round/... ./internal/agents/evaluator/... ./internal/adapters/backend/... ./internal/adapters/providers/... ./internal/adapters/trace/...`
- `nix develop -c searchbench-go-test-all`
- `nix develop -c searchbench-golangci`
- `nix develop -c searchbench-staticcheck`
- `nix develop -c searchbench-architecture-check`
- `nix flake check`

Made with [Cursor](https://cursor.com)