### PR TITLE
Build round match execution for issue #47

### DIFF
--- a/internal/adapters/dataset/lca/source.go
+++ b/internal/adapters/dataset/lca/source.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	gitmaterialize "github.com/becker63/searchbench-go/internal/adapters/materialize/git"
 	"github.com/becker63/searchbench-go/internal/ports/dataset"
 	"github.com/becker63/searchbench-go/internal/pure/domain"
 )
@@ -49,7 +50,7 @@ func (Source) Matches(ctx context.Context, req dataset.Request) (domain.NonEmpty
 	config := strings.TrimSpace(req.Config)
 	split := strings.TrimSpace(req.Split)
 
-	var specs []domain.MatchSpec
+	var tasks []domain.LCATask
 	for _, raw := range rawRows {
 		if err := ctx.Err(); err != nil {
 			return domain.NonEmpty[domain.MatchSpec]{}, err
@@ -62,12 +63,38 @@ func (Source) Matches(ctx context.Context, req dataset.Request) (domain.NonEmpty
 		if err != nil {
 			return domain.NonEmpty[domain.MatchSpec]{}, fmt.Errorf("lca adapter: normalize task: %w", err)
 		}
-		specs = append(specs, task.MatchSpec())
+		tasks = append(tasks, task)
 	}
 
-	sort.Slice(specs, func(i, j int) bool {
-		return string(specs[i].ID) < string(specs[j].ID)
+	sort.Slice(tasks, func(i, j int) bool {
+		return string(tasks[i].MatchID()) < string(tasks[j].MatchID())
 	})
+
+	var mz *gitmaterialize.Materializer
+	if string(req.MaterializeCacheDir) != "" {
+		mz = &gitmaterialize.Materializer{}
+	}
+
+	var specs []domain.MatchSpec
+	for _, task := range tasks {
+		if err := ctx.Err(); err != nil {
+			return domain.NonEmpty[domain.MatchSpec]{}, err
+		}
+		t := task
+		if mz != nil {
+			mreq := gitmaterialize.MaterializeRequest{
+				Task:      t,
+				CacheDir:  req.MaterializeCacheDir,
+				RemoteURL: strings.TrimSpace(req.MaterializeRemoteURL),
+			}
+			res, err := mz.Materialize(ctx, mreq)
+			if err != nil {
+				return domain.NonEmpty[domain.MatchSpec]{}, fmt.Errorf("lca adapter: materialize %s: %w", t.MatchID(), err)
+			}
+			t = t.WithRepo(res.RootPath)
+		}
+		specs = append(specs, t.MatchSpec())
+	}
 
 	if req.MaxItems != nil {
 		if *req.MaxItems <= 0 {

--- a/internal/app/round/evaluate.go
+++ b/internal/app/round/evaluate.go
@@ -54,7 +54,7 @@ func runEvaluationResolved(ctx context.Context, plan Plan, request evaluationReq
 	runCtx, cancel := withEvaluatorTimeout(ctx, plan)
 	defer cancel()
 
-	roundReport, executions, err := runComparison(runCtx, plan, request)
+	roundReport, executions, matchExec, err := runComparison(runCtx, plan, request)
 	if err != nil {
 		return Result{}, &Error{Phase: PhaseComparisonFailed, Err: err}
 	}
@@ -82,6 +82,7 @@ func runEvaluationResolved(ctx context.Context, plan Plan, request evaluationReq
 		RoundEvidence:       evidence,
 		ObjectiveResult:     objective,
 		EvaluatorExecutions: executions,
+		MatchExecutions:     matchExec,
 	}, nil
 }
 

--- a/internal/app/round/evaluation_plan.go
+++ b/internal/app/round/evaluation_plan.go
@@ -18,6 +18,11 @@ type evaluationResolveRequest struct {
 	ParentRef          *score.ObjectiveEvidenceRef
 	ParentEvidencePath string
 	Now                func() time.Time
+
+	// DatasetMaterializeCacheDir triggers git materialization for JetBrains LCA
+	// datasets during match resolution when non-empty.
+	DatasetMaterializeCacheDir  domain.HostPath
+	DatasetMaterializeRemoteURL string
 }
 
 // Plan is the canonical app-layer evaluation projection used by execution.

--- a/internal/app/round/evaluation_resolve_round_manifest.go
+++ b/internal/app/round/evaluation_resolve_round_manifest.go
@@ -75,7 +75,7 @@ func resolveRoundManifest(ctx context.Context, cfg config.RoundSpec, manifestPat
 		parentEvidencePath = filepath.Join(parentBundlePath, "evidence.pkl")
 	}
 
-	matches, datasetConfig, err := resolveRoundMatches(ctx, manifestDir, cfg, round, parentContinuation)
+	matches, datasetConfig, err := resolveRoundMatches(ctx, manifestDir, cfg, round, parentContinuation, request)
 	if err != nil {
 		return Plan{}, err
 	}
@@ -233,17 +233,20 @@ func resolveRoundMatches(
 	cfg config.RoundSpec,
 	round *config.RoundManifest,
 	parent *pureround.Continuation,
+	request evaluationResolveRequest,
 ) (domain.NonEmpty[domain.MatchSpec], DatasetConfig, error) {
 	if round != nil && round.Matches != nil {
 		// Materialize matches via dataset.MatchSource (JetBrains LCA JSONL under
 		// the manifest directory, or the local fake for other selections).
 		matches, err := defaultMatchSource.Matches(ctx, dataset.Request{
-			ManifestDir: manifestDir,
-			Kind:        round.Matches.Kind,
-			Name:        round.Matches.Name,
-			Config:      round.Matches.Config,
-			Split:       round.Matches.Split,
-			MaxItems:    round.Matches.MaxItems,
+			ManifestDir:          manifestDir,
+			Kind:                 round.Matches.Kind,
+			Name:                 round.Matches.Name,
+			Config:               round.Matches.Config,
+			Split:                round.Matches.Split,
+			MaxItems:             round.Matches.MaxItems,
+			MaterializeCacheDir:  request.DatasetMaterializeCacheDir,
+			MaterializeRemoteURL: request.DatasetMaterializeRemoteURL,
 		})
 		if err != nil {
 			return domain.NonEmpty[domain.MatchSpec]{}, DatasetConfig{}, fmt.Errorf("resolve matches: %w", err)

--- a/internal/app/round/evaluation_types.go
+++ b/internal/app/round/evaluation_types.go
@@ -47,4 +47,5 @@ type Result struct {
 	RoundEvidence       score.RoundEvidenceDocument
 	ObjectiveResult     *score.ObjectiveResult
 	EvaluatorExecutions []EvaluatorExecution
+	MatchExecutions     []report.MatchExecutionRecord
 }

--- a/internal/app/round/evaluator.go
+++ b/internal/app/round/evaluator.go
@@ -20,7 +20,7 @@ import (
 	"github.com/becker63/searchbench-go/internal/pure/report"
 )
 
-func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (report.RoundReport, []EvaluatorExecution, error) {
+func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (report.RoundReport, []EvaluatorExecution, []report.MatchExecutionRecord, error) {
 	allowedTools := make(map[string]struct{}, len(plan.Evaluator.ToolPolicy.EffectiveAllowed))
 	for _, name := range plan.Evaluator.ToolPolicy.EffectiveAllowed {
 		allowedTools[name] = struct{}{}
@@ -67,12 +67,16 @@ func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (r
 		},
 		Parallelism: plan.Parallelism,
 	}
-	out, err := runner.Run(ctx, plan.ComparePlan())
+	out, taskWork, err := runner.RunWithTaskWork(ctx, plan.ComparePlan())
 	if err != nil {
-		return report.RoundReport{}, nil, err
+		return report.RoundReport{}, nil, nil, err
+	}
+	matchExec, err := matchExecutionRecordsFromTaskWork(plan.Matches, taskWork)
+	if err != nil {
+		return report.RoundReport{}, nil, nil, err
 	}
 	out.CreatedAt = plan.CreatedAt
-	return out, executor.executions(), nil
+	return out, executor.executions(), matchExec, nil
 }
 
 type evaluatorExecutor struct {

--- a/internal/app/round/internal/compare/runner.go
+++ b/internal/app/round/internal/compare/runner.go
@@ -96,11 +96,18 @@ type TaskComparisonResult struct {
 // summarizes metric comparisons, asks the Decider for a decision,
 // and emits a report-safe RoundReport.
 func (r Runner) Run(ctx context.Context, plan Plan) (report.RoundReport, error) {
+	out, _, err := r.RunWithTaskWork(ctx, plan)
+	return out, err
+}
+
+// RunWithTaskWork runs the comparison and returns ordered per-task results
+// alongside the aggregate round report.
+func (r Runner) RunWithTaskWork(ctx context.Context, plan Plan) (report.RoundReport, []TaskWorkResult, error) {
 	if err := plan.Validate(); err != nil {
-		return report.RoundReport{}, err
+		return report.RoundReport{}, nil, err
 	}
 	if err := r.Validate(); err != nil {
-		return report.RoundReport{}, err
+		return report.RoundReport{}, nil, err
 	}
 
 	parallelism := r.normalizedParallelism()
@@ -116,9 +123,17 @@ func (r Runner) Run(ctx context.Context, plan Plan) (report.RoundReport, error) 
 
 	taskResults, err := r.RunTasks(ctx, plan)
 	if err != nil {
-		return report.RoundReport{}, err
+		return report.RoundReport{}, nil, err
 	}
 
+	out, err := r.finishRoundReport(plan, taskResults, logger)
+	if err != nil {
+		return report.RoundReport{}, taskResults, err
+	}
+	return out, taskResults, nil
+}
+
+func (r Runner) finishRoundReport(plan Plan, taskResults []TaskWorkResult, logger Logger) (report.RoundReport, error) {
 	results := NewResults(plan.Matches.Len())
 	for _, taskResult := range taskResults {
 		results.AddTaskResult(taskResult.Result)

--- a/internal/app/round/match_execution.go
+++ b/internal/app/round/match_execution.go
@@ -1,0 +1,46 @@
+package round
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	"github.com/becker63/searchbench-go/internal/pure/report"
+)
+
+func matchExecutionRecordsFromTaskWork(matches domain.NonEmpty[domain.MatchSpec], work []compare.TaskWorkResult) ([]report.MatchExecutionRecord, error) {
+	if len(work) != matches.Len() {
+		return nil, fmt.Errorf("match execution records: task work len %d != matches len %d", len(work), matches.Len())
+	}
+	sorted := slices.Clone(work)
+	slices.SortFunc(sorted, func(a, b compare.TaskWorkResult) int {
+		return cmp.Compare(a.Index, b.Index)
+	})
+	all := matches.All()
+	out := make([]report.MatchExecutionRecord, 0, len(sorted))
+	for i, tw := range sorted {
+		if tw.Index != i {
+			return nil, fmt.Errorf("match execution records: unexpected task index %d at position %d", tw.Index, i)
+		}
+		if tw.MatchID != all[i].ID {
+			return nil, fmt.Errorf("match execution records: match id %s != plan match id %s", tw.MatchID, all[i].ID)
+		}
+		tr := tw.Result
+		out = append(out, report.MatchExecutionRecord{
+			MatchID: tw.MatchID,
+			Task:    all[i],
+			Incumbent: report.NewRoleExecutionOutcome(
+				tr.Runs.Incumbent,
+				tr.Failures.Incumbent,
+			),
+			Challenger: report.NewRoleExecutionOutcome(
+				tr.Runs.Challenger,
+				tr.Failures.Challenger,
+			),
+			Regressions: append([]report.Regression(nil), tr.Regressions...),
+		})
+	}
+	return out, nil
+}

--- a/internal/app/round/match_execution_test.go
+++ b/internal/app/round/match_execution_test.go
@@ -1,0 +1,54 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+
+func TestMatchExecutionRecordsFromTaskWorkPreservesOrder(t *testing.T) {
+	t.Parallel()
+	a := domain.MatchSpec{ID: domain.MatchID("a")}
+	b := domain.MatchSpec{ID: domain.MatchID("b")}
+	matches, err := domain.NonEmptyFromSlice([]domain.MatchSpec{a, b})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss, err := score.NewScoreSet(
+		score.Metric[score.HopDistance]{Name: score.MetricGoldHop, Value: 1},
+		score.Metric[score.HopDistance]{Name: score.MetricIssueHop, Value: 1},
+		score.Metric[score.EfficiencyScore]{Name: score.MetricTokenEfficiency, Value: 0.5},
+		score.Metric[score.CostScore]{Name: score.MetricCost, Value: 0.5},
+		score.Metric[score.CompositeScore]{Name: score.MetricComposite, Value: 0.5},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ex := run.ExecutedRun{}
+	sr := score.ScoredRun{Execution: ex, Scores: ss}
+
+	work := []compare.TaskWorkResult{
+		{Index: 1, MatchID: b.ID, Result: compare.TaskComparisonResult{
+			Runs: domain.NewPair(&sr, (*score.ScoredRun)(nil)),
+		}},
+		{Index: 0, MatchID: a.ID, Result: compare.TaskComparisonResult{
+			Runs: domain.NewPair((*score.ScoredRun)(nil), &sr),
+		}},
+	}
+	got, err := matchExecutionRecordsFromTaskWork(matches, work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len %d", len(got))
+	}
+	if got[0].MatchID != a.ID || got[1].MatchID != b.ID {
+		t.Fatalf("order wrong: %#v", got)
+	}
+	if got[0].Challenger.Scored == nil || got[1].Incumbent.Scored == nil {
+		t.Fatal("expected scored pointers preserved")
+	}
+}

--- a/internal/app/round/run.go
+++ b/internal/app/round/run.go
@@ -2,9 +2,11 @@ package round
 
 import (
 	"context"
+	"strings"
 
 	bundlefs "github.com/becker63/searchbench-go/internal/adapters/bundle/fs"
 	"github.com/becker63/searchbench-go/internal/games/codelocalization"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
 	"github.com/becker63/searchbench-go/internal/pure/game"
 	"github.com/becker63/searchbench-go/internal/pure/report"
 	pureround "github.com/becker63/searchbench-go/internal/pure/round"
@@ -81,10 +83,12 @@ func ResolveGame(_ context.Context, _ Input) (game.Contract, error) {
 // ResolveRound loads and normalizes the caller's round manifest.
 func ResolveRound(ctx context.Context, resolvedGame game.Contract, input Input) (Resolved, error) {
 	roundPlan, err := resolveEvaluation(ctx, evaluationResolveRequest{
-		ManifestPath:       input.EvaluationManifestPath,
-		BundleRootOverride: roundBundleRoot(input.BundleRootOverride),
-		BundleID:           input.RoundID,
-		Now:                input.Now,
+		ManifestPath:                input.EvaluationManifestPath,
+		BundleRootOverride:          roundBundleRoot(input.BundleRootOverride),
+		BundleID:                    input.RoundID,
+		Now:                         input.Now,
+		DatasetMaterializeCacheDir:  domain.HostPath(strings.TrimSpace(input.DatasetMaterializeCacheDir)),
+		DatasetMaterializeRemoteURL: strings.TrimSpace(input.DatasetMaterializeRemoteURL),
 	})
 	if err != nil {
 		return Resolved{}, err
@@ -111,7 +115,7 @@ func EvaluateMatches(ctx context.Context, resolved Resolved, input Input) (Match
 	runCtx, cancel := withEvaluatorTimeout(ctx, plan)
 	defer cancel()
 
-	roundReport, executions, err := runComparison(runCtx, plan, evaluationRequestFromInput(input))
+	roundReport, executions, matchExec, err := runComparison(runCtx, plan, evaluationRequestFromInput(input))
 	if err != nil {
 		return MatchRecords{}, &Error{Phase: PhaseComparisonFailed, Err: err}
 	}
@@ -119,6 +123,7 @@ func EvaluateMatches(ctx context.Context, resolved Resolved, input Input) (Match
 		Plan:                plan,
 		RoundReport:         roundReport,
 		EvaluatorExecutions: executions,
+		MatchExecutions:     matchExec,
 	}, nil
 }
 
@@ -183,16 +188,19 @@ func buildResult(
 		RoundEvidence:       evidence,
 		ObjectiveResult:     objective,
 		EvaluatorExecutions: matches.EvaluatorExecutions,
+		MatchExecutions:     matches.MatchExecutions,
 	}
 }
 
 func evaluationRequestFromInput(input Input) evaluationRequest {
 	return evaluationRequest{
 		Resolve: evaluationResolveRequest{
-			ManifestPath:       input.EvaluationManifestPath,
-			BundleRootOverride: roundBundleRoot(input.BundleRootOverride),
-			BundleID:           input.RoundID,
-			Now:                input.Now,
+			ManifestPath:                input.EvaluationManifestPath,
+			BundleRootOverride:          roundBundleRoot(input.BundleRootOverride),
+			BundleID:                    input.RoundID,
+			Now:                         input.Now,
+			DatasetMaterializeCacheDir:  domain.HostPath(strings.TrimSpace(input.DatasetMaterializeCacheDir)),
+			DatasetMaterializeRemoteURL: strings.TrimSpace(input.DatasetMaterializeRemoteURL),
 		},
 		DisableRenderReport:   input.DisableRenderReport,
 		EvaluatorModelFactory: input.EvaluatorModelFactory,

--- a/internal/app/round/types.go
+++ b/internal/app/round/types.go
@@ -26,6 +26,11 @@ type Input struct {
 	EvaluatorModelFactory EvaluatorModelFactory
 	EvaluatorToolFactory  EvaluatorToolFactory
 	OptimizerModelFactory OptimizerModelFactory
+
+	// DatasetMaterializeCacheDir triggers JetBrains LCA git materialization during
+	// manifest resolution when non-empty.
+	DatasetMaterializeCacheDir  string
+	DatasetMaterializeRemoteURL string
 }
 
 // Resolved is the normalized round contract before match execution.
@@ -42,6 +47,7 @@ type MatchRecords struct {
 	Plan                Plan
 	RoundReport         report.RoundReport
 	EvaluatorExecutions []EvaluatorExecution
+	MatchExecutions     []report.MatchExecutionRecord
 }
 
 // Record is the completed round workflow outcome.

--- a/internal/ports/dataset/dataset.go
+++ b/internal/ports/dataset/dataset.go
@@ -20,7 +20,16 @@ type Request struct {
 	Config      string
 	Split       string
 	MaxItems    *int
+
+	// MaterializeCacheDir, when non-empty, asks JetBrains LCA adapters to git
+	// materialize each task's repo into this cache root before returning MatchSpec rows.
+	MaterializeCacheDir HostPath
+	// MaterializeRemoteURL optionally overrides the default GitHub HTTPS remote.
+	MaterializeRemoteURL string
 }
+
+// HostPath is re-exported so dataset callers do not import domain only for paths.
+type HostPath = domain.HostPath
 
 // MatchSource is the port rounds use to materialize the match list. Adapters
 // must return at least one match.

--- a/internal/pure/report/match_execution_record.go
+++ b/internal/pure/report/match_execution_record.go
@@ -1,0 +1,30 @@
+package report
+
+import (
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+
+// RoleExecutionOutcome captures one policy role outcome for a single match.
+type RoleExecutionOutcome struct {
+	Scored *score.ScoredRun
+	Failed *run.RunFailure
+}
+
+// NewRoleExecutionOutcome constructs an outcome from mutually exclusive pointers.
+func NewRoleExecutionOutcome(scored *score.ScoredRun, failed *run.RunFailure) RoleExecutionOutcome {
+	return RoleExecutionOutcome{Scored: scored, Failed: failed}
+}
+
+// MatchExecutionRecord aligns one planned match with incumbent/challenger outcomes.
+//
+// It preserves task index order via construction from ordered compare.TaskWorkResult
+// slices and is the durable seam for downstream localization evidence builders.
+type MatchExecutionRecord struct {
+	MatchID     domain.MatchID       `json:"match_id"`
+	Task        domain.MatchSpec     `json:"task"`
+	Incumbent   RoleExecutionOutcome `json:"incumbent"`
+	Challenger  RoleExecutionOutcome `json:"challenger"`
+	Regressions []Regression         `json:"regressions,omitempty"`
+}

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -264,6 +264,8 @@ internal/
       evaluator_runtime_test.go
       evaluator.go
       example_fixtures_test.go
+      match_execution_test.go
+      match_execution.go
       match_source.go
       prepared_tools.go
       run_test.go
@@ -328,6 +330,7 @@ internal/
       doc.go
       evidence_test.go
       evidence.go
+      match_execution_record.go
       match_execution_set_test.go
       match_execution_set.go
       regression.go
@@ -8618,6 +8621,7 @@ import (
 	"sort"
 	"strings"
 
+	gitmaterialize "github.com/becker63/searchbench-go/internal/adapters/materialize/git"
 	"github.com/becker63/searchbench-go/internal/ports/dataset"
 	"github.com/becker63/searchbench-go/internal/pure/domain"
 )
@@ -8629,6 +8633,7 @@ import (
 "sort"
 "strings"
 ⋮----
+gitmaterialize "github.com/becker63/searchbench-go/internal/adapters/materialize/git"
 "github.com/becker63/searchbench-go/internal/ports/dataset"
 "github.com/becker63/searchbench-go/internal/pure/domain"
 ⋮----
@@ -8641,9 +8646,13 @@ func NewSource() Source
 // applies MaxItems windowing when set.
 func (Source) Matches(ctx context.Context, req dataset.Request) (domain.NonEmpty[domain.MatchSpec], error)
 ⋮----
-var specs []domain.MatchSpec
+var tasks []domain.LCATask
 ⋮----
 var row domain.LCAHFRow
+⋮----
+var mz *gitmaterialize.Materializer
+⋮----
+var specs []domain.MatchSpec
 </file>
 
 <file path="internal/adapters/materialize/git/cache_key.go">
@@ -11948,6 +11957,12 @@ type TaskComparisonResult struct {
 // and emits a report-safe RoundReport.
 func (r Runner) Run(ctx context.Context, plan Plan) (report.RoundReport, error)
 ⋮----
+// RunWithTaskWork runs the comparison and returns ordered per-task results
+// alongside the aggregate round report.
+func (r Runner) RunWithTaskWork(ctx context.Context, plan Plan) (report.RoundReport, []TaskWorkResult, error)
+⋮----
+func (r Runner) finishRoundReport(plan Plan, taskResults []TaskWorkResult, logger Logger) (report.RoundReport, error)
+⋮----
 // Validate checks that Runner has the injected dependencies needed to
 // orchestrate a comparison.
 func (r Runner) Validate() error
@@ -12314,7 +12329,15 @@ type evaluationResolveRequest struct {
 	ParentRef          *score.ObjectiveEvidenceRef
 	ParentEvidencePath string
 	Now                func() time.Time
+
+	// DatasetMaterializeCacheDir triggers git materialization for JetBrains LCA
+	// datasets during match resolution when non-empty.
+	DatasetMaterializeCacheDir  domain.HostPath
+	DatasetMaterializeRemoteURL string
 }
+⋮----
+// DatasetMaterializeCacheDir triggers git materialization for JetBrains LCA
+// datasets during match resolution when non-empty.
 ⋮----
 // Plan is the canonical app-layer evaluation projection used by execution.
 type Plan struct {
@@ -12519,6 +12542,7 @@ func resolveRoundMatches(
 	cfg config.RoundSpec,
 	round *config.RoundManifest,
 	parent *pureround.Continuation,
+	request evaluationResolveRequest,
 ) (domain.NonEmpty[domain.MatchSpec], DatasetConfig, error)
 ⋮----
 // Materialize matches via dataset.MatchSource (JetBrains LCA JSONL under
@@ -12793,6 +12817,7 @@ type Result struct {
 	RoundEvidence       score.RoundEvidenceDocument
 	ObjectiveResult     *score.ObjectiveResult
 	EvaluatorExecutions []EvaluatorExecution
+	MatchExecutions     []report.MatchExecutionRecord
 }
 </file>
 
@@ -12887,7 +12912,7 @@ evaluatorfake "github.com/becker63/searchbench-go/internal/agents/evaluator/fake
 run "github.com/becker63/searchbench-go/internal/pure/execution"
 "github.com/becker63/searchbench-go/internal/pure/report"
 ⋮----
-func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (report.RoundReport, []EvaluatorExecution, error)
+func runComparison(ctx context.Context, plan Plan, request evaluationRequest) (report.RoundReport, []EvaluatorExecution, []report.MatchExecutionRecord, error)
 ⋮----
 type evaluatorExecutor struct {
 	modelFactory EvaluatorModelFactory
@@ -12947,6 +12972,52 @@ func TestWriteExampleRoundFixtures(t *testing.T)
 func resetExampleBundleDir(t *testing.T, path string)
 ⋮----
 func scriptedExampleOptimizerFactory() OptimizerModelFactory
+</file>
+
+<file path="internal/app/round/match_execution_test.go">
+package round
+⋮----
+import (
+	"testing"
+
+	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+⋮----
+"testing"
+⋮----
+"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+"github.com/becker63/searchbench-go/internal/pure/score"
+⋮----
+func TestMatchExecutionRecordsFromTaskWorkPreservesOrder(t *testing.T)
+</file>
+
+<file path="internal/app/round/match_execution.go">
+package round
+⋮----
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	"github.com/becker63/searchbench-go/internal/pure/report"
+)
+⋮----
+"cmp"
+"fmt"
+"slices"
+⋮----
+"github.com/becker63/searchbench-go/internal/app/round/internal/compare"
+"github.com/becker63/searchbench-go/internal/pure/domain"
+"github.com/becker63/searchbench-go/internal/pure/report"
+⋮----
+func matchExecutionRecordsFromTaskWork(matches domain.NonEmpty[domain.MatchSpec], work []compare.TaskWorkResult) ([]report.MatchExecutionRecord, error)
 </file>
 
 <file path="internal/app/round/match_source.go">
@@ -13074,9 +13145,11 @@ package round
 ⋮----
 import (
 	"context"
+	"strings"
 
 	bundlefs "github.com/becker63/searchbench-go/internal/adapters/bundle/fs"
 	"github.com/becker63/searchbench-go/internal/games/codelocalization"
+	"github.com/becker63/searchbench-go/internal/pure/domain"
 	"github.com/becker63/searchbench-go/internal/pure/game"
 	"github.com/becker63/searchbench-go/internal/pure/report"
 	pureround "github.com/becker63/searchbench-go/internal/pure/round"
@@ -13084,9 +13157,11 @@ import (
 )
 ⋮----
 "context"
+"strings"
 ⋮----
 bundlefs "github.com/becker63/searchbench-go/internal/adapters/bundle/fs"
 "github.com/becker63/searchbench-go/internal/games/codelocalization"
+"github.com/becker63/searchbench-go/internal/pure/domain"
 "github.com/becker63/searchbench-go/internal/pure/game"
 "github.com/becker63/searchbench-go/internal/pure/report"
 pureround "github.com/becker63/searchbench-go/internal/pure/round"
@@ -13192,7 +13267,15 @@ type Input struct {
 	EvaluatorModelFactory EvaluatorModelFactory
 	EvaluatorToolFactory  EvaluatorToolFactory
 	OptimizerModelFactory OptimizerModelFactory
+
+	// DatasetMaterializeCacheDir triggers JetBrains LCA git materialization during
+	// manifest resolution when non-empty.
+	DatasetMaterializeCacheDir  string
+	DatasetMaterializeRemoteURL string
 }
+⋮----
+// DatasetMaterializeCacheDir triggers JetBrains LCA git materialization during
+// manifest resolution when non-empty.
 ⋮----
 // Resolved is the normalized round contract before match execution.
 type Resolved struct {
@@ -13208,6 +13291,7 @@ type MatchRecords struct {
 	Plan                Plan
 	RoundReport         report.RoundReport
 	EvaluatorExecutions []EvaluatorExecution
+	MatchExecutions     []report.MatchExecutionRecord
 }
 ⋮----
 // Record is the completed round workflow outcome.
@@ -13354,7 +13438,20 @@ type Request struct {
 	Config      string
 	Split       string
 	MaxItems    *int
+
+	// MaterializeCacheDir, when non-empty, asks JetBrains LCA adapters to git
+	// materialize each task's repo into this cache root before returning MatchSpec rows.
+	MaterializeCacheDir HostPath
+	// MaterializeRemoteURL optionally overrides the default GitHub HTTPS remote.
+	MaterializeRemoteURL string
 }
+⋮----
+// MaterializeCacheDir, when non-empty, asks JetBrains LCA adapters to git
+// materialize each task's repo into this cache root before returning MatchSpec rows.
+⋮----
+// MaterializeRemoteURL optionally overrides the default GitHub HTTPS remote.
+⋮----
+// HostPath is re-exported so dataset callers do not import domain only for paths.
 ⋮----
 // MatchSource is the port rounds use to materialize the match list. Adapters
 // must return at least one match.
@@ -15112,6 +15209,41 @@ var (
 // BuildRoundEvidence projects a round report into the pure round evidence
 // document used by artifact serialization and objective layers.
 func BuildRoundEvidence(roundReport RoundReport) (score.RoundEvidenceDocument, error)
+</file>
+
+<file path="internal/pure/report/match_execution_record.go">
+package report
+⋮----
+import (
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/domain"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+"github.com/becker63/searchbench-go/internal/pure/score"
+⋮----
+// RoleExecutionOutcome captures one policy role outcome for a single match.
+type RoleExecutionOutcome struct {
+	Scored *score.ScoredRun
+	Failed *run.RunFailure
+}
+⋮----
+// NewRoleExecutionOutcome constructs an outcome from mutually exclusive pointers.
+func NewRoleExecutionOutcome(scored *score.ScoredRun, failed *run.RunFailure) RoleExecutionOutcome
+⋮----
+// MatchExecutionRecord aligns one planned match with incumbent/challenger outcomes.
+//
+// It preserves task index order via construction from ordered compare.TaskWorkResult
+// slices and is the durable seam for downstream localization evidence builders.
+type MatchExecutionRecord struct {
+	MatchID     domain.MatchID       `json:"match_id"`
+	Task        domain.MatchSpec     `json:"task"`
+	Incumbent   RoleExecutionOutcome `json:"incumbent"`
+	Challenger  RoleExecutionOutcome `json:"challenger"`
+	Regressions []Regression         `json:"regressions,omitempty"`
+}
 </file>
 
 <file path="internal/pure/report/match_execution_set_test.go">


### PR DESCRIPTION
Implements #47 on top of the evaluator runtime and adapter base.

- Ordered per-match execution seam: `report.MatchExecutionRecord`, built from `compare.Runner.RunWithTaskWork`.
- `MatchRecords` / `Result` carry `MatchExecutions` for downstream evidence (#48).
- Optional JetBrains LCA git materialization during dataset resolution via `Input.DatasetMaterializeCacheDir` / `dataset.Request.MaterializeCacheDir`.

Does not implement #48 localization evidence enrichment beyond the seam.

Validation: `go test ./...`, pre-push hooks (golangci, staticcheck, flake check).

Made with [Cursor](https://cursor.com)