### PR TITLE
Build localization evidence from match executions for issue #48

### DIFF
--- a/internal/app/round/evaluate.go
+++ b/internal/app/round/evaluate.go
@@ -59,7 +59,7 @@ func runEvaluationResolved(ctx context.Context, plan Plan, request evaluationReq
 		return Result{}, &Error{Phase: PhaseComparisonFailed, Err: err}
 	}
 
-	evidence, err := buildEvidenceFromReport(plan, roundReport)
+	evidence, err := projectRoundEvidence(plan, roundReport, matchExec)
 	if err != nil {
 		return Result{}, &Error{Phase: PhaseRoundEvidenceFailed, Err: err}
 	}
@@ -104,6 +104,15 @@ func buildEvidenceFromReport(plan Plan, roundReport report.RoundReport) (score.R
 	if err := evidence.Validate(); err != nil {
 		return score.RoundEvidenceDocument{}, err
 	}
+	return evidence, nil
+}
+
+func projectRoundEvidence(plan Plan, roundReport report.RoundReport, matchExec []report.MatchExecutionRecord) (score.RoundEvidenceDocument, error) {
+	evidence, err := buildEvidenceFromReport(plan, roundReport)
+	if err != nil {
+		return score.RoundEvidenceDocument{}, err
+	}
+	enrichLocalizationEvidence(&evidence, matchExec)
 	return evidence, nil
 }
 

--- a/internal/app/round/localization_evidence.go
+++ b/internal/app/round/localization_evidence.go
@@ -1,0 +1,52 @@
+package round
+
+import (
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	"github.com/becker63/searchbench-go/internal/pure/report"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+
+func enrichLocalizationEvidence(evidence *score.RoundEvidenceDocument, records []report.MatchExecutionRecord) {
+	if evidence == nil || len(records) == 0 {
+		return
+	}
+	n := 0
+	for _, rec := range records {
+		gold := rec.Task.Oracle.GoldFiles
+		n += countPredictionMisses(rec.Incumbent, gold)
+		n += countPredictionMisses(rec.Challenger, gold)
+	}
+	evidence.InvalidPredictions = score.InvalidPredictionEvidence{
+		Known: true,
+		Count: n,
+	}
+}
+
+func countPredictionMisses(out report.RoleExecutionOutcome, gold []domain.RepoRelPath) int {
+	if out.Failed != nil || out.Scored == nil {
+		return 0
+	}
+	if predictionMissesGold(out.Scored.Execution.Prediction, gold) {
+		return 1
+	}
+	return 0
+}
+
+func predictionMissesGold(pred domain.Prediction, gold []domain.RepoRelPath) bool {
+	if len(gold) == 0 {
+		return len(pred.Files) == 0
+	}
+	if len(pred.Files) == 0 {
+		return true
+	}
+	want := make(map[domain.RepoRelPath]struct{}, len(gold))
+	for _, g := range gold {
+		want[g] = struct{}{}
+	}
+	for _, f := range pred.Files {
+		if _, ok := want[f]; ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/round/localization_evidence_test.go
+++ b/internal/app/round/localization_evidence_test.go
@@ -1,0 +1,137 @@
+package round
+
+import (
+	"testing"
+	"time"
+
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/pure/report"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+
+func TestEnrichLocalizationEvidenceCountsPredictionMisses(t *testing.T) {
+	t.Parallel()
+	gold := domain.RepoRelPath("pkg/gold.go")
+	task := domain.MatchSpec{
+		ID:        domain.MatchID("m1"),
+		Benchmark: domain.BenchmarkLCA,
+		Oracle:    domain.MatchOracle{GoldFiles: []domain.RepoRelPath{gold}},
+	}
+	inc := scoredRunForLocalizationTestRole(t, task, domain.RoleIncumbent, domain.Prediction{Files: []domain.RepoRelPath{"pkg/wrong.go"}})
+	ch := scoredRunForLocalizationTestRole(t, task, domain.RoleChallenger, domain.Prediction{Files: []domain.RepoRelPath{gold}})
+	rec := []report.MatchExecutionRecord{{
+		MatchID:    task.ID,
+		Task:       task,
+		Incumbent:  report.NewRoleExecutionOutcome(&inc, nil),
+		Challenger: report.NewRoleExecutionOutcome(&ch, nil),
+	}}
+	ev := score.RoundEvidenceDocument{SchemaVersion: score.EvidenceSchemaVersion, ReportID: domain.ReportID("r1")}
+	enrichLocalizationEvidence(&ev, rec)
+	if !ev.InvalidPredictions.Known || ev.InvalidPredictions.Count != 1 {
+		t.Fatalf("InvalidPredictions = %#v, want known:true count:1", ev.InvalidPredictions)
+	}
+}
+
+func TestProjectRoundEvidenceLeavesUsageUnavailableWhenRunsOmitUsage(t *testing.T) {
+	t.Parallel()
+	gold := domain.RepoRelPath("pkg/gold.go")
+	task := domain.MatchSpec{
+		ID:        domain.MatchID("m1"),
+		Benchmark: domain.BenchmarkLCA,
+		Oracle:    domain.MatchOracle{GoldFiles: []domain.RepoRelPath{gold}},
+	}
+	incSys := domain.SystemSpec{
+		ID:           domain.SystemID("inc"),
+		Name:         "Inc",
+		Backend:      domain.BackendFake,
+		Model:        domain.ModelSpec{Provider: "fake", Name: "fake"},
+		PromptBundle: domain.PromptBundleRef{Name: "b"},
+	}
+	chSys := domain.SystemSpec{
+		ID:           domain.SystemID("ch"),
+		Name:         "Ch",
+		Backend:      domain.BackendFake,
+		Model:        domain.ModelSpec{Provider: "fake", Name: "fake"},
+		PromptBundle: domain.PromptBundleRef{Name: "b"},
+	}
+	inc := scoredRunForLocalizationTestNoUsage(t, task, incSys, domain.RoleIncumbent, domain.Prediction{Files: []domain.RepoRelPath{gold}})
+	ch := scoredRunForLocalizationTestNoUsage(t, task, chSys, domain.RoleChallenger, domain.Prediction{Files: []domain.RepoRelPath{gold}})
+	tasks, err := domain.NonEmptyFromSlice([]domain.MatchSpec{task})
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := report.NewComparisonSpec(domain.NewPair(incSys, chSys), tasks)
+	rr := report.NewRoundReport(
+		domain.ReportID("report-usage-test"),
+		spec,
+		domain.NewPair([]score.ScoredRun{inc}, []score.ScoredRun{ch}),
+		domain.NewPair([]run.RunFailure{}, []run.RunFailure{}),
+		[]report.ScoreComparison{
+			report.NewScoreComparison(score.MetricComposite, 0.2, 0.8),
+		},
+		nil,
+		report.Decision{Decision: report.DecisionReview, Reason: "test"},
+	)
+	rr.CreatedAt = time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	plan := Plan{
+		Game:     GameConfig{ID: "game"},
+		Round:    RoundConfig{ID: "round"},
+		ReportID: domain.ReportID("report-usage-test"),
+	}
+	got, err := projectRoundEvidence(plan, rr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ChallengerUsage.Available || got.IncumbentUsage.Available {
+		t.Fatalf("usage should stay unavailable when modeled usage summaries are empty: challenger=%#v incumbent=%#v",
+			got.ChallengerUsage, got.IncumbentUsage)
+	}
+	if got.ChallengerUsage.TotalTokens != 0 || got.IncumbentUsage.TotalTokens != 0 {
+		t.Fatalf("token totals should not invent zeros as measurements: challenger=%#v incumbent=%#v",
+			got.ChallengerUsage, got.IncumbentUsage)
+	}
+}
+
+func scoredRunForLocalizationTestRole(t *testing.T, task domain.MatchSpec, role domain.Role, pred domain.Prediction) score.ScoredRun {
+	t.Helper()
+	sys := domain.SystemSpec{
+		ID:           domain.SystemID("sys"),
+		Name:         "Sys",
+		Backend:      domain.BackendFake,
+		Model:        domain.ModelSpec{Provider: "fake", Name: "fake"},
+		PromptBundle: domain.PromptBundleRef{Name: "b"},
+	}
+	return scoredRunForLocalizationTestNoUsage(t, task, sys, role, pred)
+}
+
+func scoredRunForLocalizationTestNoUsage(t *testing.T, task domain.MatchSpec, sys domain.SystemSpec, role domain.Role, pred domain.Prediction) score.ScoredRun {
+	t.Helper()
+	spec := run.NewSpec(domain.RunID(string(role)+"-"+task.ID.String()), task, sys)
+	planned := run.NewPlanned(spec)
+	prepared := run.NewPrepared(planned, domain.SessionID("session-"+task.ID.String()))
+	executed := run.NewExecuted(
+		prepared,
+		pred,
+		domain.UsageSummary{},
+		domain.TraceID("trace-"+task.ID.String()),
+		time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 12, 12, 0, 1, 0, time.UTC),
+	)
+	ss, err := score.NewScoreSet(
+		score.Metric[score.HopDistance]{Name: score.MetricGoldHop, Value: 1},
+		score.Metric[score.HopDistance]{Name: score.MetricIssueHop, Value: 1},
+		score.Metric[score.EfficiencyScore]{Name: score.MetricTokenEfficiency, Value: 0.5},
+		score.Metric[score.CostScore]{Name: score.MetricCost, Value: 0.5},
+		score.Metric[score.CompositeScore]{Name: score.MetricComposite, Value: 0.5},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sr, err := score.NewScoredRun(executed, ss)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sr
+}

--- a/internal/app/round/run.go
+++ b/internal/app/round/run.go
@@ -130,7 +130,7 @@ func EvaluateMatches(ctx context.Context, resolved Resolved, input Input) (Match
 // BuildEvidence projects the durable round evidence from the match records.
 // It must not write any bundle artifacts.
 func BuildEvidence(_ game.Contract, _ Resolved, matches MatchRecords) (score.RoundEvidenceDocument, error) {
-	evidence, err := buildEvidenceFromReport(matches.Plan, matches.RoundReport)
+	evidence, err := projectRoundEvidence(matches.Plan, matches.RoundReport, matches.MatchExecutions)
 	if err != nil {
 		return score.RoundEvidenceDocument{}, &Error{Phase: PhaseRoundEvidenceFailed, Err: err}
 	}

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -264,6 +264,8 @@ internal/
       evaluator_runtime_test.go
       evaluator.go
       example_fixtures_test.go
+      localization_evidence_test.go
+      localization_evidence.go
       match_execution_test.go
       match_execution.go
       match_source.go
@@ -12182,6 +12184,8 @@ func withEvaluatorTimeout(ctx context.Context, plan Plan) (context.Context, cont
 ⋮----
 func buildEvidenceFromReport(plan Plan, roundReport report.RoundReport) (score.RoundEvidenceDocument, error)
 ⋮----
+func projectRoundEvidence(plan Plan, roundReport report.RoundReport, matchExec []report.MatchExecutionRecord) (score.RoundEvidenceDocument, error)
+⋮----
 func evaluateObjectiveForPlan(ctx context.Context, plan Plan, evidence score.RoundEvidenceDocument, request evaluationRequest) (*score.ObjectiveResult, error)
 ⋮----
 func writeRoundBundle(
@@ -12972,6 +12976,56 @@ func TestWriteExampleRoundFixtures(t *testing.T)
 func resetExampleBundleDir(t *testing.T, path string)
 ⋮----
 func scriptedExampleOptimizerFactory() OptimizerModelFactory
+</file>
+
+<file path="internal/app/round/localization_evidence_test.go">
+package round
+⋮----
+import (
+	"testing"
+	"time"
+
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	run "github.com/becker63/searchbench-go/internal/pure/execution"
+	"github.com/becker63/searchbench-go/internal/pure/report"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+⋮----
+"testing"
+"time"
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/domain"
+run "github.com/becker63/searchbench-go/internal/pure/execution"
+"github.com/becker63/searchbench-go/internal/pure/report"
+"github.com/becker63/searchbench-go/internal/pure/score"
+⋮----
+func TestEnrichLocalizationEvidenceCountsPredictionMisses(t *testing.T)
+⋮----
+func TestProjectRoundEvidenceLeavesUsageUnavailableWhenRunsOmitUsage(t *testing.T)
+⋮----
+func scoredRunForLocalizationTestRole(t *testing.T, task domain.MatchSpec, role domain.Role, pred domain.Prediction) score.ScoredRun
+⋮----
+func scoredRunForLocalizationTestNoUsage(t *testing.T, task domain.MatchSpec, sys domain.SystemSpec, role domain.Role, pred domain.Prediction) score.ScoredRun
+</file>
+
+<file path="internal/app/round/localization_evidence.go">
+package round
+⋮----
+import (
+	"github.com/becker63/searchbench-go/internal/pure/domain"
+	"github.com/becker63/searchbench-go/internal/pure/report"
+	"github.com/becker63/searchbench-go/internal/pure/score"
+)
+⋮----
+"github.com/becker63/searchbench-go/internal/pure/domain"
+"github.com/becker63/searchbench-go/internal/pure/report"
+"github.com/becker63/searchbench-go/internal/pure/score"
+⋮----
+func enrichLocalizationEvidence(evidence *score.RoundEvidenceDocument, records []report.MatchExecutionRecord)
+⋮----
+func countPredictionMisses(out report.RoleExecutionOutcome, gold []domain.RepoRelPath) int
+⋮----
+func predictionMissesGold(pred domain.Prediction, gold []domain.RepoRelPath) bool
 </file>
 
 <file path="internal/app/round/match_execution_test.go">


### PR DESCRIPTION
Stacked on PR #47. Implements #48: localization enrichment + usage honesty test. Validation: go test ./...

Made with [Cursor](https://cursor.com)